### PR TITLE
fix: accept `onfocusin`/`onfocusout` in `a11y_mouse_events_have_key_events`

### DIFF
--- a/.changeset/large-schools-smell.md
+++ b/.changeset/large-schools-smell.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: accept `onfocusin`/`onfocusout` in `a11y_mouse_events_have_key_events`

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -360,7 +360,7 @@ Enforce that heading elements (`h1`, `h2`, etc.) and anchors have content and th
 '%event%' event must be accompanied by '%accompanied_by%' event
 ```
 
-Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users. Because `focus` and `blur` do not bubble, `onfocusin` and `onfocusout` are accepted in their place — they are the only way for an element that is not itself focusable to react to focus changes within it.
+Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` (or `onfocusin`) and `onblur` (or `onfocusout`), respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users.
 
 ```svelte
 <!-- A11y: onmouseover must be accompanied by onfocus -->

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -360,7 +360,7 @@ Enforce that heading elements (`h1`, `h2`, etc.) and anchors have content and th
 '%event%' event must be accompanied by '%accompanied_by%' event
 ```
 
-Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users.
+Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users. Because `focus` and `blur` do not bubble, `onfocusin` and `onfocusout` are accepted in their place — they are the only way for an element that is not itself focusable to react to focus changes within it.
 
 ```svelte
 <!-- A11y: onmouseover must be accompanied by onfocus -->

--- a/packages/svelte/messages/compile-warnings/a11y.md
+++ b/packages/svelte/messages/compile-warnings/a11y.md
@@ -300,7 +300,7 @@ Enforce that heading elements (`h1`, `h2`, etc.) and anchors have content and th
 
 > '%event%' event must be accompanied by '%accompanied_by%' event
 
-Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users.
+Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users. Because `focus` and `blur` do not bubble, `onfocusin` and `onfocusout` are accepted in their place — they are the only way for an element that is not itself focusable to react to focus changes within it.
 
 ```svelte
 <!-- A11y: onmouseover must be accompanied by onfocus -->

--- a/packages/svelte/messages/compile-warnings/a11y.md
+++ b/packages/svelte/messages/compile-warnings/a11y.md
@@ -300,7 +300,7 @@ Enforce that heading elements (`h1`, `h2`, etc.) and anchors have content and th
 
 > '%event%' event must be accompanied by '%accompanied_by%' event
 
-Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` and `onblur`, respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users. Because `focus` and `blur` do not bubble, `onfocusin` and `onfocusout` are accepted in their place — they are the only way for an element that is not itself focusable to react to focus changes within it.
+Enforce that `onmouseover` and `onmouseout` are accompanied by `onfocus` (or `onfocusin`) and `onblur` (or `onfocusout`), respectively. This helps to ensure that any functionality triggered by these mouse events is also accessible to keyboard users.
 
 ```svelte
 <!-- A11y: onmouseover must be accompanied by onfocus -->

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js
@@ -373,11 +373,23 @@ export function check_element(node, context) {
 		}
 	}
 
-	if (!has_spread && handlers.has('mouseover') && !handlers.has('focus')) {
+	// `focus`/`blur` don't bubble, so an element that isn't focusable itself can only be notified
+	// about focus changes inside it through `focusin`/`focusout` — accept those as well
+	if (
+		!has_spread &&
+		handlers.has('mouseover') &&
+		!handlers.has('focus') &&
+		!handlers.has('focusin')
+	) {
 		w.a11y_mouse_events_have_key_events(node, 'mouseover', 'focus');
 	}
 
-	if (!has_spread && handlers.has('mouseout') && !handlers.has('blur')) {
+	if (
+		!has_spread &&
+		handlers.has('mouseout') &&
+		!handlers.has('blur') &&
+		!handlers.has('focusout')
+	) {
 		w.a11y_mouse_events_have_key_events(node, 'mouseout', 'blur');
 	}
 

--- a/packages/svelte/tests/validator/samples/a11y-mouse-events-have-key-events/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-mouse-events-have-key-events/input.svelte
@@ -17,3 +17,7 @@
 <div onmouseout={() => {}} onblur={() => {}}></div>
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div onmouseout={() => {}} {...otherProps}></div>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onmouseover={() => {}} onfocusin={() => {}}></div>
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onmouseout={() => {}} onfocusout={() => {}}></div>


### PR DESCRIPTION
Fixes #8089

`a11y_mouse_events_have_key_events` currently accepts only `focus` as a partner for `mouseover` and only `blur` as a partner for `mouseout`. But `focus` and `blur` do not bubble, so an element that is not itself focusable — the common case for a hover-triggered tooltip wrapper, a `<div>`, a heading — can never receive them. The bubbling equivalents are `focusin` and `focusout`.

The result is that correct markup gets warned about, and the only way to silence the warning is to attach a handler that can never fire:

```svelte
<!-- warns today, even though this is the accessible version -->
<h1 onmouseover={show} onfocusin={show}>Hello</h1>

<!-- doesn't warn, but `onfocus` never fires on a non-focusable <h1> -->
<h1 onmouseover={show} onfocus={show}>Hello</h1>
```

This widens the check to treat `focusin`/`focusout` as satisfying the rule, which is what [@f-elix suggested on the issue](https://github.com/sveltejs/svelte/issues/8089#issuecomment-4262949941). No new API and no new warnings — it strictly removes false positives; markup with neither `focus` nor `focusin` still warns.

### Changes

- `a11y/index.js`: accept `focusin` alongside `focus`, and `focusout` alongside `blur`
- `messages/compile-warnings/a11y.md`: document the accepted alternatives (+ regenerated `documentation/docs/98-reference/.generated/compile-warnings.md` via `pnpm generate`)
- Two cases added to the `a11y-mouse-events-have-key-events` validator sample

## Test plan

```sh
FILTER=a11y-mouse-events-have-key-events pnpm test packages/svelte/tests/validator/test.ts
#  Tests  3 passed | 3 skipped (6)

pnpm test
#  Test Files  34 passed (34)
#  Tests  7753 passed | 69 skipped (7822)

pnpm lint          # clean
pnpm --filter svelte check   # clean
```

The new fixture cases fail without the source change (the compiler emits two unexpected `a11y_mouse_events_have_key_events` warnings on lines 21 and 23), and the two pre-existing cases — `<div onmouseover>` and `<div onmouseout>` with no focus partner at all — still warn, so the rule is not simply disabled.
