### PR TITLE
fix: allow `role="tab"` on `<label>` elements

### DIFF
--- a/.changeset/thick-goats-invite.md
+++ b/.changeset/thick-goats-invite.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: allow `role="tab"` on `<label>` elements

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/constants.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/constants.js
@@ -178,7 +178,9 @@ export const a11y_non_interactive_element_to_interactive_role_exceptions = {
 	li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
 	table: ['grid'],
 	td: ['gridcell'],
-	fieldset: ['radiogroup', 'presentation']
+	fieldset: ['radiogroup', 'presentation'],
+	// <label role="tab"> wrapping a radio input is the standard way to build tabs without JavaScript
+	label: ['tab']
 };
 
 export const combobox_if_list = ['email', 'search', 'tel', 'text', 'url'];

--- a/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-to-interactive-role/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-no-noninteractive-element-to-interactive-role/input.svelte
@@ -76,6 +76,8 @@
 <menu role="tablist"></menu>
 <menu role="tree"></menu>
 <menu role="treegrid"></menu>
+<!-- label -->
+<label role="tab">tab <input type="checkbox" /></label>
 
 <!-- VALID: elements assigned an interactive role. -->
 <div role="button"></div>


### PR DESCRIPTION
Fixes #14450

```svelte
<label role="tab">tab <input type="checkbox" /></label>
```

currently warns with `a11y_no_noninteractive_element_to_interactive_role`, but this is the standard way to build tabs that work without JavaScript, and `<label>` is [interactive content](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) per the HTML spec.

### Why it happens

`<label>` has no entry in `aria-query`'s `elementRoles`, so `element_interactivity()` falls through to the AXObject branch, where `elementAXObjects` maps `label` to `LabelRole` and `AXObjects.get('LabelRole').type === 'structure'`. That puts `<label>` in `non_interactive_element_ax_object_schemas`, and since `tab` is a widget role, the rule fires.

### The fix, and the fix I didn't make

This adds `label: ['tab']` to `a11y_non_interactive_element_to_interactive_role_exceptions` — the same escape hatch the file already uses for `ul`/`ol`/`menu`/`li`/`table`/`td`/`fieldset`, and the same shape as #17638.

The broader alternative would be to reclassify `<label>` as interactive outright, matching the HTML spec. I tried that and rejected it, because it makes the inverse rule misfire: with `<label>` classified as interactive, `<label role="presentation">` and `<label role="none">` start emitting `a11y_no_interactive_element_to_noninteractive_role`, and genuinely wrong markup like `<label role="textbox">` and `<label role="button">` stops warning at all. Measured on this branch:

```
# <label> reclassified as interactive
3 a11y_no_interactive_element_to_noninteractive_role | `<label>` cannot have role 'presentation'
4 a11y_no_interactive_element_to_noninteractive_role | `<label>` cannot have role 'none'

# this PR
2 a11y_no_noninteractive_element_to_interactive_role | Non-interactive element `<label>` cannot have interactive role 'textbox'
5 a11y_no_noninteractive_element_to_interactive_role | Non-interactive element `<label>` cannot have interactive role 'button'
```

Scoping the exception to `tab` fixes the reported false positive without loosening anything else. If reclassifying `<label>` is the direction the team prefers, happy to redo it that way.

### Changes

- `a11y/constants.js`: `label: ['tab']` in the exceptions map
- One case added to the `a11y-no-noninteractive-element-to-interactive-role` validator sample

## Test plan

```sh
FILTER=a11y-no-noninteractive-element-to-interactive-role pnpm test packages/svelte/tests/validator/test.ts
#  Tests  3 passed | 3 skipped (6)

pnpm test
#  Test Files  34 passed (34)
#  Tests  7753 passed | 69 skipped (7822)

pnpm lint          # clean
pnpm --filter svelte check   # clean
```

The new fixture case fails without the constants change (an unexpected `a11y_no_noninteractive_element_to_interactive_role` on `<label>`/`tab`). `warnings.json` is unchanged, which is the point: the sample's existing `<label role="textbox">` on line 28 still warns, so the exception really is scoped to `tab`.
