### PR TITLE
fix: preserve line feed character references in attribute values

### DIFF
--- a/.changeset/tricky-donkeys-clap.md
+++ b/.changeset/tricky-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: preserve line feed character references in attribute values

--- a/packages/svelte/src/compiler/phases/1-parse/utils/html.js
+++ b/packages/svelte/src/compiler/phases/1-parse/utils/html.js
@@ -60,7 +60,7 @@ export function decode_character_references(html, is_attribute_value) {
 				return match;
 			}
 
-			return String.fromCodePoint(validate_code(code));
+			return String.fromCodePoint(validate_code(code, is_attribute_value));
 		}
 	);
 }
@@ -75,10 +75,15 @@ const NUL = 0;
 // Also see: https://en.wikipedia.org/wiki/Plane_(Unicode)
 // Also see: https://html.spec.whatwg.org/multipage/parsing.html#preprocessing-the-input-stream
 
-/** @param {number} code */
-function validate_code(code) {
-	// line feed becomes generic whitespace
-	if (code === 10) {
+/**
+ * @param {number} code
+ * @param {boolean} is_attribute_value
+ */
+function validate_code(code, is_attribute_value) {
+	// line feed becomes generic whitespace, since it is collapsed along with the
+	// surrounding whitespace anyway. In an attribute value it is significant, so it
+	// is left alone there
+	if (code === 10 && !is_attribute_value) {
 		return 32;
 	}
 

--- a/packages/svelte/tests/parser-legacy/samples/convert-entities-line-feed/input.svelte
+++ b/packages/svelte/tests/parser-legacy/samples/convert-entities-line-feed/input.svelte
@@ -1,0 +1,1 @@
+<p title="A&#x0A;B">A&#x0A;B</p>

--- a/packages/svelte/tests/parser-legacy/samples/convert-entities-line-feed/output.json
+++ b/packages/svelte/tests/parser-legacy/samples/convert-entities-line-feed/output.json
@@ -1,0 +1,53 @@
+{
+	"html": {
+		"type": "Fragment",
+		"start": 0,
+		"end": 32,
+		"children": [
+			{
+				"type": "Element",
+				"start": 0,
+				"end": 32,
+				"name": "p",
+				"attributes": [
+					{
+						"type": "Attribute",
+						"start": 3,
+						"end": 19,
+						"name": "title",
+						"name_loc": {
+							"start": {
+								"line": 1,
+								"column": 3,
+								"character": 3
+							},
+							"end": {
+								"line": 1,
+								"column": 8,
+								"character": 8
+							}
+						},
+						"value": [
+							{
+								"start": 10,
+								"end": 18,
+								"type": "Text",
+								"raw": "A&#x0A;B",
+								"data": "A\nB"
+							}
+						]
+					}
+				],
+				"children": [
+					{
+						"type": "Text",
+						"start": 20,
+						"end": 28,
+						"raw": "A&#x0A;B",
+						"data": "A B"
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/Component.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/Component.svelte
@@ -1,0 +1,5 @@
+<script>
+	const { text } = $props();
+</script>
+
+<span id="prop">{text}</span>

--- a/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/_config.js
@@ -1,0 +1,15 @@
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		// a line feed entity in an attribute value stays a line feed...
+		assert.equal(target.querySelector('#attr')?.getAttribute('title'), 'A\nB');
+		assert.equal(target.querySelector('#attr-decimal')?.getAttribute('title'), 'A\nB');
+
+		// ...including when the attribute is a prop passed to a component
+		assert.equal(target.querySelector('#prop')?.textContent, 'A\nB');
+
+		// other entities in attribute values still decode
+		assert.equal(target.querySelector('#attr-other-entity')?.getAttribute('title'), '©');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/html-entity-line-feed/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import Component from './Component.svelte';
+</script>
+
+<span id="attr" title="A&#x0A;B"></span>
+<span id="attr-decimal" title="A&#10;B"></span>
+<span id="attr-other-entity" title="&copy;"></span>
+
+<Component text="A&#x0A;B" />


### PR DESCRIPTION
Fixes #15555

`<span title="A&#x0A;B">` currently renders with a space instead of a line break, so there is no way to get a newline into an attribute value using a character reference. `&#x0D;` works, and `title={'A\nB'}` works, but the LF entity silently loses the newline.

### Why it happens

`decode_character_references()` already knows whether it is decoding an attribute value — `is_attribute_value` is threaded in from `element.js` (`true`) and `text.js` (`false`) — but the flag stops at the call to `validate_code()` on line 63. `validate_code()` unconditionally maps code point 10 to 32:

```js
// line feed becomes generic whitespace
if (code === 10) {
	return 32;
}
```

That is correct for text content, where the line feed would be collapsed along with the surrounding whitespace anyway, but an attribute value is not whitespace-normalized, so the collapse is simply lossy there.

### The fix

Pass `is_attribute_value` down to `validate_code()` and skip the collapse when it is set. Nothing else changes: every other code point takes the same path it did before, and text content still collapses.

### Changes

- `1-parse/utils/html.js`: thread `is_attribute_value` into `validate_code()` and guard the LF collapse with it
- `tests/parser-legacy/samples/convert-entities-line-feed`: AST snapshot pinning both halves — `<p title="A&#x0A;B">A&#x0A;B</p>` parses to `data: "A\nB"` for the attribute and `data: "A B"` for the text
- `tests/runtime-runes/samples/html-entity-line-feed`: the reported case end to end — hex and decimal LF entities on `title`, an LF entity in a prop passed to a component, and a `&copy;` control to show ordinary entities still decode

## Test plan

```sh
pnpm test
#  Test Files  34 passed (34)
#  Tests  7756 passed | 69 skipped (7825)
#  (7753 on main, +3 from the new fixtures)

pnpm lint                    # clean
pnpm --filter svelte check   # clean
```

Reverting just the `html.js` change turns both fixtures red:

```
FAIL packages/svelte/tests/runtime-runes/test.ts > html-entity-line-feed (dom)
FAIL packages/svelte/tests/runtime-runes/test.ts > html-entity-line-feed (hydrate)
AssertionError: expected 'A B' to equal 'A\nB'

FAIL packages/svelte/tests/parser-legacy/test.ts > convert-entities-line-feed
-  "data": "A\nB",
+  "data": "A B",
```

The parser snapshot is deliberately the one that guards against over-fixing: in that diff only the *attribute* `data` moves, the text `data` stays `"A B"`. Replacing the guard with a wholesale removal of the LF rule flips the other half red instead, on the text node, so the fixture pins the behaviour in both directions.

One thing I noticed while writing the runtime test but did not touch, since it is unrelated and predates this change: for text content the client backend inlines the raw source into the template (`$.from_html(\`<span>A&#x0A;B</span>\`)`) and lets the browser decode it, so the DOM ends up with a real newline, while SSR emits the collapsed `A B`. That client/SSR divergence is identical before and after this PR. Happy to open a separate issue for it if it is worth tracking.
