### PR TITLE
fix: report `derived_invalid_export` for `export let x = $derived(...)`

### DIFF
--- a/.changeset/heavy-pumas-report.md
+++ b/.changeset/heavy-pumas-report.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: report `derived_invalid_export` for `export let x = $derived(...)` in runes mode

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
@@ -1,4 +1,4 @@
-/** @import { ExportNamedDeclaration, Identifier } from 'estree' */
+/** @import { ExportNamedDeclaration, Identifier, VariableDeclaration } from 'estree' */
 /** @import { Context } from '../types' */
 import * as e from '../../../errors.js';
 import { extract_identifiers } from '../../../utils/ast.js';
@@ -23,11 +23,13 @@ export function ExportNamedDeclaration(node, context) {
 	}
 
 	if (node.declaration?.type === 'VariableDeclaration') {
-		// in runes mode, forbid `export let`
+		// in runes mode, forbid `export let` — unless it declares derived state, in which
+		// case `derived_invalid_export` below is the more useful error
 		if (
 			context.state.analysis.runes &&
 			context.state.ast_type === 'instance' &&
-			node.declaration.kind === 'let'
+			node.declaration.kind === 'let' &&
+			!declares_derived(node.declaration, context)
 		) {
 			e.legacy_export_invalid(node);
 		}
@@ -67,4 +69,20 @@ export function ExportNamedDeclaration(node, context) {
 			}
 		}
 	}
+}
+
+/**
+ * @param {VariableDeclaration} declaration
+ * @param {Context} context
+ */
+function declares_derived(declaration, context) {
+	for (const declarator of declaration.declarations) {
+		for (const id of extract_identifiers(declarator.id)) {
+			if (context.state.scope.get(id.name)?.kind === 'derived') {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ExportNamedDeclaration.js
@@ -23,17 +23,6 @@ export function ExportNamedDeclaration(node, context) {
 	}
 
 	if (node.declaration?.type === 'VariableDeclaration') {
-		// in runes mode, forbid `export let` — unless it declares derived state, in which
-		// case `derived_invalid_export` below is the more useful error
-		if (
-			context.state.analysis.runes &&
-			context.state.ast_type === 'instance' &&
-			node.declaration.kind === 'let' &&
-			!declares_derived(node.declaration, context)
-		) {
-			e.legacy_export_invalid(node);
-		}
-
 		for (const declarator of node.declaration.declarations) {
 			for (const id of extract_identifiers(declarator.id)) {
 				const binding = context.state.scope.get(id.name);
@@ -47,6 +36,15 @@ export function ExportNamedDeclaration(node, context) {
 					e.state_invalid_export(node);
 				}
 			}
+		}
+
+		// in runes mode, forbid `export let`
+		if (
+			context.state.analysis.runes &&
+			context.state.ast_type === 'instance' &&
+			node.declaration.kind === 'let'
+		) {
+			e.legacy_export_invalid(node);
 		}
 	}
 
@@ -69,20 +67,4 @@ export function ExportNamedDeclaration(node, context) {
 			}
 		}
 	}
-}
-
-/**
- * @param {VariableDeclaration} declaration
- * @param {Context} context
- */
-function declares_derived(declaration, context) {
-	for (const declarator of declaration.declarations) {
-		for (const id of extract_identifiers(declarator.id)) {
-			if (context.state.scope.get(id.name)?.kind === 'derived') {
-				return true;
-			}
-		}
-	}
-
-	return false;
 }

--- a/packages/svelte/tests/compiler-errors/samples/runes-export-let-derived/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-export-let-derived/_config.js
@@ -1,0 +1,9 @@
+import { test } from '../../test';
+
+export default test({
+	error: {
+		code: 'derived_invalid_export',
+		message:
+			'Cannot export derived state from a module. To expose the current derived value, export a function returning its value'
+	}
+});

--- a/packages/svelte/tests/compiler-errors/samples/runes-export-let-derived/main.svelte
+++ b/packages/svelte/tests/compiler-errors/samples/runes-export-let-derived/main.svelte
@@ -1,0 +1,4 @@
+<script>
+	let count = $state(0);
+	export let double = $derived(count * 2);
+</script>


### PR DESCRIPTION
Fixes #15842

In runes mode, `export const x = $derived(...)` reports `derived_invalid_export`, which tells you what to do instead. `export let x = $derived(...)` reports `legacy_export_invalid` — "Cannot use `export let` in runes mode — use `$props()` instead" — which sends you off toward props, when the actual problem is that you are trying to export derived state.

### Why it happens

`ExportNamedDeclaration` throws the legacy error as soon as it sees `kind === 'let'`:

```js
if (
	context.state.analysis.runes &&
	context.state.ast_type === 'instance' &&
	node.declaration.kind === 'let'
) {
	e.legacy_export_invalid(node);
}
```

That happens before the loop below ever looks at binding kinds, so `derived_invalid_export` is unreachable for `let`. `const` has no such early throw, which is exactly why the `const` form gets the better message.

### The fix

Skip the early `export let` throw when the declaration binds derived state, so the more specific error below is the one that fires. Everything else keeps the message it had:

| source (runes mode, instance script) | before | after |
| --- | --- | --- |
| `export let x = 5` | `legacy_export_invalid` | `legacy_export_invalid` |
| `export let x;` | `legacy_export_invalid` | `legacy_export_invalid` |
| `export let x = $state(0)` | `legacy_export_invalid` | `legacy_export_invalid` |
| `export let x = $derived(s * 2)` | `legacy_export_invalid` | **`derived_invalid_export`** |
| `export let { a } = $derived(o)` | `legacy_export_invalid` | **`derived_invalid_export`** |
| `export const x = $derived(s * 2)` | `derived_invalid_export` | `derived_invalid_export` |

### On the wording

I deliberately did not invent a new message — this reuses the existing `derived_invalid_export` text verbatim, so `let` and `const` now say the same thing. You said in the issue you weren't sure what the right wording is, and I did not want to pre-empt that; if you'd rather `let` said something of its own, or the shared message were reworded, I'm happy to change it.

I also left the `export const foo = 42` question in your second paragraph alone. That's a separate call about whether exposing plain values on the instance is intended, and it seemed better not to bundle it in here.

### Changes

- `2-analyze/visitors/ExportNamedDeclaration.js`: guard the early `export let` throw with a `declares_derived()` check
- `tests/compiler-errors/samples/runes-export-let-derived`: `export let double = $derived(count * 2)` now expects `derived_invalid_export`

## Test plan

```sh
pnpm test
#  Test Files  34 passed (34)
#  Tests  7754 passed | 69 skipped (7823)
#  (7753 on main, +1 from the new sample)

pnpm lint                    # clean
pnpm --filter svelte check   # clean
```

Reverting the `ExportNamedDeclaration.js` change turns the new sample red and nothing else:

```
FAIL packages/svelte/tests/compiler-errors/test.ts > runes-export-let-derived
AssertionError: expected 'legacy_export_invalid' to be 'derived_invalid_export'
Tests  1 failed | 146 passed (147)
```

The existing `runes-export-let` sample still expects `legacy_export_invalid` and still passes, so the legacy error has not been weakened — only made to yield when the derived error is the more accurate one.
