### PR TITLE
fix: end a restored reaction context at the end of its synchronous segment

### DIFF
--- a/.changeset/quiet-context-segment.md
+++ b/.changeset/quiet-context-segment.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: end a restored reaction context at the end of its synchronous segment

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -285,11 +285,10 @@ export function analyze_module(source, options) {
 		runes: true,
 		immutable: true,
 		tracing: false,
-		async_deriveds: new Set(),
+		async_deriveds: new Map(),
 		comments,
 		classes: new Map(),
-		pickled_awaits: new Set(),
-		reactive_awaits: new Set()
+		pickled_awaits: new Set()
 	};
 
 	state.adjust({
@@ -558,9 +557,8 @@ export function analyze_component(root, source, options) {
 		source,
 		snippet_renderers: new Map(),
 		snippets: new Set(),
-		async_deriveds: new Set(),
+		async_deriveds: new Map(),
 		pickled_awaits: new Set(),
-		reactive_awaits: new Set(),
 		instance_body: {
 			sync: [],
 			async: [],

--- a/packages/svelte/src/compiler/phases/2-analyze/index.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/index.js
@@ -288,7 +288,8 @@ export function analyze_module(source, options) {
 		async_deriveds: new Set(),
 		comments,
 		classes: new Map(),
-		pickled_awaits: new Set()
+		pickled_awaits: new Set(),
+		reactive_awaits: new Set()
 	};
 
 	state.adjust({
@@ -559,6 +560,7 @@ export function analyze_component(root, source, options) {
 		snippets: new Set(),
 		async_deriveds: new Set(),
 		pickled_awaits: new Set(),
+		reactive_awaits: new Set(),
 		instance_body: {
 			sync: [],
 			async: [],

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/AwaitExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/AwaitExpression.js
@@ -10,15 +10,18 @@ import * as e from '../../../errors.js';
 export function AwaitExpression(node, context) {
 	const tla = context.state.ast_type === 'instance' && context.state.function_depth === 1;
 
-	// preserve context for awaits that precede other expressions in template or `$derived(...)`
 	if (
 		is_reactive_expression(
 			context.path,
 			context.state.derived_function_depth === context.state.function_depth
-		) &&
-		!is_last_evaluated_expression(context.path, node)
+		)
 	) {
-		context.state.analysis.pickled_awaits.add(node);
+		context.state.analysis.reactive_awaits.add(node);
+
+		// preserve context for awaits that precede other expressions in template or `$derived(...)`
+		if (!is_last_evaluated_expression(context.path, node)) {
+			context.state.analysis.pickled_awaits.add(node);
+		}
 	}
 
 	let suspend = tla;

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/AwaitExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/AwaitExpression.js
@@ -1,6 +1,7 @@
 /** @import { AwaitExpression, Expression, SpreadElement, Property } from 'estree' */
 /** @import { Context } from '../types' */
 /** @import { AST } from '#compiler' */
+/** @import { ExpressionMetadata } from '../../nodes.js' */
 import * as e from '../../../errors.js';
 
 /**
@@ -16,11 +17,13 @@ export function AwaitExpression(node, context) {
 			context.state.derived_function_depth === context.state.function_depth
 		)
 	) {
-		context.state.analysis.reactive_awaits.add(node);
+		const expression = /** @type {ExpressionMetadata} */ (context.state.expression);
 
-		// preserve context for awaits that precede other expressions in template or `$derived(...)`
-		if (!is_last_evaluated_expression(context.path, node)) {
+		// preserve context for awaits that precede other expressions in template or `$derived(...)`,
+		// and for any await that follows one, so the restored context ends at the next suspension
+		if (expression.has_pickled_await || !is_last_evaluated_expression(context.path, node)) {
 			context.state.analysis.pickled_awaits.add(node);
+			expression.has_pickled_await = true;
 		}
 	}
 

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -253,7 +253,7 @@ export function CallExpression(node, context) {
 		});
 
 		if (expression.has_await) {
-			context.state.analysis.async_deriveds.add(node);
+			context.state.analysis.async_deriveds.set(node, expression);
 		}
 
 		// Tell surrounding declaration tag about metadata for correct calculation of blockers etc

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -1,8 +1,9 @@
-/** @import { BlockStatement, Expression, Identifier } from 'estree' */
+/** @import { BlockStatement, CallExpression, Expression, Identifier, Node } from 'estree' */
 /** @import { Binding } from '#compiler' */
 /** @import { ClientTransformState, ComponentClientTransformState } from './types.js' */
 /** @import { Analysis } from '../../types.js' */
 /** @import { Scope } from '../../scope.js' */
+import { walk } from 'zimmerframe';
 import * as b from '#compiler/builders';
 import { is_simple_expression, save } from '../../../utils/ast.js';
 import {
@@ -164,6 +165,96 @@ export function should_proxy(node, scope) {
 	return true;
 }
 
+/** @param {Node} node */
+function is_function(node) {
+	return (
+		node.type === 'ArrowFunctionExpression' ||
+		node.type === 'FunctionExpression' ||
+		node.type === 'FunctionDeclaration'
+	);
+}
+
+/**
+ * @param {Node} node
+ * @param {string} name
+ */
+function is_internal_call(node, name) {
+	// `b.call('$.name', ...)` emits a single identifier named `$.name`
+	return (
+		node.type === 'CallExpression' &&
+		node.callee.type === 'Identifier' &&
+		node.callee.name === `$.${name}`
+	);
+}
+
+/**
+ * Whether `$.<name>(...)` is called anywhere in `node` outside nested functions
+ * @param {Node} node
+ * @param {string} name
+ */
+function contains_internal_call(node, name) {
+	let found = false;
+
+	walk(node, null, {
+		_(node, { next, stop }) {
+			if (is_function(node)) return;
+			if (is_internal_call(node, name)) {
+				found = true;
+				stop();
+			}
+			next();
+		}
+	});
+
+	return found;
+}
+
+/**
+ * An async thunk whose body ends by unsetting any reaction context restored by
+ * `$.save` in its last synchronous segment, so the context cannot leak into
+ * foreign microtasks that run before the returned promise settles
+ * @param {Expression | BlockStatement} body
+ */
+export function async_thunk(body) {
+	// only a `$.save` can restore a context, so a thunk without one needs no hooks —
+	// drop the `$.suspend` calls the await visitor emitted optimistically
+	if (!contains_internal_call(body, 'save')) {
+		return b.arrow(
+			[],
+			/** @type {Expression | BlockStatement} */ (
+				walk(/** @type {Node} */ (body), null, {
+					_(node, { next, visit }) {
+						if (is_function(node)) return;
+						if (is_internal_call(node, 'suspend')) {
+							return visit(/** @type {CallExpression} */ (node).arguments[0]);
+						}
+						next();
+					}
+				})
+			),
+			true
+		);
+	}
+
+	// expression bodies end through `$.suspend`, which is the same hook as a suspension
+	if (body.type !== 'BlockStatement') {
+		return b.arrow([], b.call('$.suspend', body), true);
+	}
+
+	return b.arrow(
+		[],
+		b.block([
+			{
+				type: 'TryStatement',
+				block: body,
+				handler: null,
+				finalizer: b.block([b.stmt(b.call('$.unset_restored_context'))])
+			}
+		]),
+		true
+	);
+}
+
 /**
  * Svelte legacy mode should use safe equals in most places, runes mode shouldn't
  * @param {ComponentClientTransformState} state
@@ -171,7 +262,7 @@ export function should_proxy(node, scope) {
  * @param {boolean} [async]
  */
 export function create_derived(state, expression, async = false) {
-	const thunk = b.thunk(expression, async);
+	const thunk = async ? async_thunk(expression) : b.thunk(expression);
 
 	if (async) {
 		return save(b.call('$.async_derived', thunk));

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -1,9 +1,9 @@
-/** @import { BlockStatement, CallExpression, Expression, Identifier, Node } from 'estree' */
+/** @import { BlockStatement, Expression, Identifier } from 'estree' */
 /** @import { Binding } from '#compiler' */
 /** @import { ClientTransformState, ComponentClientTransformState } from './types.js' */
 /** @import { Analysis } from '../../types.js' */
+/** @import { ExpressionMetadata } from '../../nodes.js' */
 /** @import { Scope } from '../../scope.js' */
-import { walk } from 'zimmerframe';
 import * as b from '#compiler/builders';
 import { is_simple_expression, save } from '../../../utils/ast.js';
 import {
@@ -165,80 +165,21 @@ export function should_proxy(node, scope) {
 	return true;
 }
 
-/** @param {Node} node */
-function is_function(node) {
-	return (
-		node.type === 'ArrowFunctionExpression' ||
-		node.type === 'FunctionExpression' ||
-		node.type === 'FunctionDeclaration'
-	);
-}
-
 /**
- * @param {Node} node
- * @param {string} name
- */
-function is_internal_call(node, name) {
-	// `b.call('$.name', ...)` emits a single identifier named `$.name`
-	return (
-		node.type === 'CallExpression' &&
-		node.callee.type === 'Identifier' &&
-		node.callee.name === `$.${name}`
-	);
-}
-
-/**
- * Whether `$.<name>(...)` is called anywhere in `node` outside nested functions
- * @param {Node} node
- * @param {string} name
- */
-function contains_internal_call(node, name) {
-	let found = false;
-
-	walk(node, null, {
-		_(node, { next, stop }) {
-			if (is_function(node)) return;
-			if (is_internal_call(node, name)) {
-				found = true;
-				stop();
-			}
-			next();
-		}
-	});
-
-	return found;
-}
-
-/**
- * An async thunk whose body ends by unsetting any reaction context restored by
- * `$.save` in its last synchronous segment, so the context cannot leak into
- * foreign microtasks that run before the returned promise settles
+ * An async thunk. If an `await` inside restores the reaction context via `$.save`,
+ * the body ends with `$.unsave` so the context cannot leak into foreign microtasks
+ * that run before the returned promise settles. If the body throws instead, the
+ * context is unset by the consumer's `finally`, as before
  * @param {Expression | BlockStatement} body
+ * @param {ExpressionMetadata} metadata
  */
-export function async_thunk(body) {
-	// only a `$.save` can restore a context, so a thunk without one needs no hooks —
-	// drop the `$.suspend` calls the await visitor emitted optimistically
-	if (!contains_internal_call(body, 'save')) {
-		return b.arrow(
-			[],
-			/** @type {Expression | BlockStatement} */ (
-				walk(/** @type {Node} */ (body), null, {
-					_(node, { next, visit }) {
-						if (is_function(node)) return;
-						if (is_internal_call(node, 'suspend')) {
-							return visit(/** @type {CallExpression} */ (node).arguments[0]);
-						}
-						next();
-					}
-				})
-			),
-			true
-		);
+export function async_thunk(body, metadata) {
+	if (!metadata.has_pickled_await) {
+		return b.arrow([], body, true);
 	}
 
-	// expression bodies end through `$.suspend`, which is the same hook as a suspension
 	if (body.type !== 'BlockStatement') {
-		return b.arrow([], b.call('$.suspend', body), true);
+		return b.arrow([], b.call('$.unsave', body), true);
 	}
 
 	return b.arrow(
@@ -248,7 +189,7 @@ export function async_thunk(body) {
 				type: 'TryStatement',
 				block: body,
 				handler: null,
-				finalizer: b.block([b.stmt(b.call('$.unset_restored_context'))])
+				finalizer: b.block([b.stmt(b.call('$.unsave'))])
 			}
 		]),
 		true
@@ -259,16 +200,14 @@ export function async_thunk(body) {
  * Svelte legacy mode should use safe equals in most places, runes mode shouldn't
  * @param {ComponentClientTransformState} state
  * @param {Expression | BlockStatement} expression
- * @param {boolean} [async]
+ * @param {ExpressionMetadata} [metadata]
  */
-export function create_derived(state, expression, async = false) {
-	const thunk = async ? async_thunk(expression) : b.thunk(expression);
-
-	if (async) {
-		return save(b.call('$.async_derived', thunk));
-	} else {
-		return b.call(state.analysis.runes ? '$.derived' : '$.derived_safe_equal', thunk);
+export function create_derived(state, expression, metadata) {
+	if (metadata?.has_await) {
+		return save(b.call('$.async_derived', async_thunk(expression, metadata)));
 	}
+
+	return b.call(state.analysis.runes ? '$.derived' : '$.derived_safe_equal', b.thunk(expression));
 }
 
 /**

--- a/packages/svelte/src/compiler/phases/3-transform/client/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/utils.js
@@ -167,9 +167,8 @@ export function should_proxy(node, scope) {
 
 /**
  * An async thunk. If an `await` inside restores the reaction context via `$.save`,
- * the body ends with `$.unsave` so the context cannot leak into foreign microtasks
- * that run before the returned promise settles. If the body throws instead, the
- * context is unset by the consumer's `finally`, as before
+ * the body exits through `$.unsave` so the context cannot leak into foreign microtasks
+ * that run before the returned promise settles
  * @param {Expression | BlockStatement} body
  * @param {ExpressionMetadata} metadata
  */
@@ -178,16 +177,14 @@ export function async_thunk(body, metadata) {
 		return b.arrow([], body, true);
 	}
 
-	if (body.type !== 'BlockStatement') {
-		return b.arrow([], b.call('$.unsave', body), true);
-	}
+	const block = body.type === 'BlockStatement' ? body : b.block([b.return(body)]);
 
 	return b.arrow(
 		[],
 		b.block([
 			{
 				type: 'TryStatement',
-				block: body,
+				block,
 				handler: null,
 				finalizer: b.block([b.stmt(b.call('$.unsave'))])
 			}

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitBlock.js
@@ -1,9 +1,9 @@
 /** @import { BlockStatement, Pattern, Statement } from 'estree' */
 /** @import { AST } from '#compiler' */
 /** @import { ComponentClientTransformState, ComponentContext } from '../types' */
-import { extract_identifiers, is_expression_async } from '../../../../utils/ast.js';
+import { extract_identifiers } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
-import { create_derived } from '../utils.js';
+import { async_thunk, create_derived } from '../utils.js';
 import { get_value } from './shared/declarations.js';
 import { build_expression, add_svelte_meta } from './shared/utils.js';
 
@@ -15,10 +15,10 @@ export function AwaitBlock(node, context) {
 	context.state.template.push_comment();
 
 	// Visit {#await <expression>} first to ensure that scopes are in the correct order
-	const expression = b.thunk(
-		build_expression(context, node.expression, node.metadata.expression),
-		node.metadata.expression.has_await
-	);
+	const input = build_expression(context, node.expression, node.metadata.expression);
+	const expression = node.metadata.expression.has_await
+		? async_thunk(input, node.metadata.expression)
+		: b.thunk(input);
 
 	let then_block;
 	let catch_block;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitExpression.js
@@ -21,11 +21,5 @@ export function AwaitExpression(node, context) {
 		return b.call(b.await(b.call('$.track_reactivity_loss', argument)));
 	}
 
-	// a context restored by an earlier pickled await must end at this suspension;
-	// `async_thunk` strips the call again in thunks that contain no `$.save`
-	else if (context.state.analysis.reactive_awaits.has(node)) {
-		return b.await(b.call('$.suspend', argument));
-	}
-
 	return argument === node.argument ? node : { ...node, argument };
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/AwaitExpression.js
@@ -21,5 +21,11 @@ export function AwaitExpression(node, context) {
 		return b.call(b.await(b.call('$.track_reactivity_loss', argument)));
 	}
 
+	// a context restored by an earlier pickled await must end at this suspension;
+	// `async_thunk` strips the call again in thunks that contain no `$.save`
+	else if (context.state.analysis.reactive_awaits.has(node)) {
+		return b.await(b.call('$.suspend', argument));
+	}
+
 	return argument === node.argument ? node : { ...node, argument };
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BlockStatement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BlockStatement.js
@@ -2,7 +2,6 @@
 /** @import { ComponentContext } from '../types' */
 import { add_state_transformers } from './shared/declarations.js';
 import * as b from '#compiler/builders';
-import { async_thunk } from '../utils.js';
 
 /**
  * @param {BlockStatement} node
@@ -23,9 +22,7 @@ export function BlockStatement(node, context) {
 		const call = b.call(
 			'$.trace',
 			/** @type {Expression} */ (tracing),
-			is_async
-				? async_thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))))
-				: b.thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))))
+			b.thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))), is_async)
 		);
 
 		return b.block([b.return(is_async ? b.await(call) : call)]);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/BlockStatement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/BlockStatement.js
@@ -2,6 +2,7 @@
 /** @import { ComponentContext } from '../types' */
 import { add_state_transformers } from './shared/declarations.js';
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 
 /**
  * @param {BlockStatement} node
@@ -22,7 +23,9 @@ export function BlockStatement(node, context) {
 		const call = b.call(
 			'$.trace',
 			/** @type {Expression} */ (tracing),
-			b.thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))), is_async)
+			is_async
+				? async_thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))))
+				: b.thunk(b.block(node.body.map((n) => /** @type {Statement} */ (context.visit(n)))))
 		);
 
 		return b.block([b.return(is_async ? b.await(call) : call)]);

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/ConstTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/ConstTag.js
@@ -19,7 +19,7 @@ export function ConstTag(node, context) {
 	if (declaration.id.type === 'Identifier') {
 		const init = build_expression(context, declaration.init, node.metadata.expression);
 
-		let expression = create_derived(context.state, init, node.metadata.expression.has_await);
+		let expression = create_derived(context.state, init, node.metadata.expression);
 
 		if (dev) {
 			expression = b.call('$.tag', expression, b.literal(declaration.id.name));
@@ -69,7 +69,7 @@ export function ConstTag(node, context) {
 					b.return(b.object(identifiers.map((node) => b.prop('init', node, node))))
 				]);
 
-		let expression = create_derived(context.state, block, node.metadata.expression.has_await);
+		let expression = create_derived(context.state, block, node.metadata.expression);
 
 		if (dev) {
 			expression = b.call('$.tag', expression, b.literal('[@const]'));

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/DeclarationTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/DeclarationTag.js
@@ -86,5 +86,5 @@ export function add_async_declaration(context, metadata, ids, assignments, kind 
 		metadata.expression.has_await ||
 		assignments.some((assignment) => has_await_expression(assignment));
 	const body = assignments.length === 1 ? assignments[0].expression : b.block(assignments);
-	run.thunks.push(has_await ? async_thunk(body) : b.thunk(body));
+	run.thunks.push(has_await ? async_thunk(body, metadata.expression) : b.thunk(body));
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/DeclarationTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/DeclarationTag.js
@@ -3,6 +3,7 @@
 /** @import { ComponentContext } from '../types' */
 import { extract_identifiers, has_await_expression } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { add_state_transformers } from './shared/declarations.js';
 
 /**
@@ -85,5 +86,5 @@ export function add_async_declaration(context, metadata, ids, assignments, kind 
 		metadata.expression.has_await ||
 		assignments.some((assignment) => has_await_expression(assignment));
 	const body = assignments.length === 1 ? assignments[0].expression : b.block(assignments);
-	run.thunks.push(b.thunk(body, has_await));
+	run.thunks.push(has_await ? async_thunk(body) : b.thunk(body));
 }

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
@@ -12,6 +12,7 @@ import {
 import { dev } from '../../../../state.js';
 import { extract_paths, object } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { get_value } from './shared/declarations.js';
 import { build_expression, add_svelte_meta } from './shared/utils.js';
 
@@ -313,7 +314,7 @@ export function EachBlock(node, context) {
 
 	const has_await = node.metadata.expression.has_await;
 
-	const get_collection = b.thunk(collection, has_await);
+	const get_collection = has_await ? async_thunk(collection) : b.thunk(collection);
 	const thunk = has_await ? b.thunk(b.call('$.get', b.id('$$collection'))) : get_collection;
 
 	const render_args = [b.id('$$anchor'), item];

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/EachBlock.js
@@ -314,7 +314,9 @@ export function EachBlock(node, context) {
 
 	const has_await = node.metadata.expression.has_await;
 
-	const get_collection = has_await ? async_thunk(collection) : b.thunk(collection);
+	const get_collection = has_await
+		? async_thunk(collection, node.metadata.expression)
+		: b.thunk(collection);
 	const thunk = has_await ? b.thunk(b.call('$.get', b.id('$$collection'))) : get_collection;
 
 	const render_args = [b.id('$$anchor'), item];

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/HtmlTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/HtmlTag.js
@@ -47,7 +47,7 @@ export function HtmlTag(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([async_thunk(expression)]) : b.void0,
+					has_await ? b.array([async_thunk(expression, node.metadata.expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$html')] : [context.state.node],
 						b.block([statement])

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/HtmlTag.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/HtmlTag.js
@@ -2,6 +2,7 @@
 /** @import { ComponentContext } from '../types' */
 import { is_ignored } from '../../../../state.js';
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { build_expression } from './shared/utils.js';
 
 /**
@@ -46,7 +47,7 @@ export function HtmlTag(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([b.thunk(expression, true)]) : b.void0,
+					has_await ? b.array([async_thunk(expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$html')] : [context.state.node],
 						b.block([statement])

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -2,6 +2,7 @@
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { build_expression, add_svelte_meta } from './shared/utils.js';
 
 /**
@@ -117,7 +118,7 @@ export function IfBlock(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([b.thunk(expression, true)]) : b.void0,
+					has_await ? b.array([async_thunk(expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$condition')] : [context.state.node],
 						b.block(statements)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/IfBlock.js
@@ -118,7 +118,7 @@ export function IfBlock(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([async_thunk(expression)]) : b.void0,
+					has_await ? b.array([async_thunk(expression, node.metadata.expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$condition')] : [context.state.node],
 						b.block(statements)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/KeyBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/KeyBlock.js
@@ -32,7 +32,7 @@ export function KeyBlock(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([async_thunk(expression)]) : b.void0,
+					has_await ? b.array([async_thunk(expression, node.metadata.expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$key')] : [context.state.node],
 						b.block([statement])

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/KeyBlock.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/KeyBlock.js
@@ -2,6 +2,7 @@
 /** @import { AST } from '#compiler' */
 /** @import { ComponentContext } from '../types' */
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { build_expression, add_svelte_meta } from './shared/utils.js';
 
 /**
@@ -31,7 +32,7 @@ export function KeyBlock(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([b.thunk(expression, true)]) : b.void0,
+					has_await ? b.array([async_thunk(expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$key')] : [context.state.node],
 						b.block([statement])

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -4,6 +4,7 @@
 import { dev, locator } from '../../../../state.js';
 import { is_text_attribute } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
+import { async_thunk } from '../utils.js';
 import { determine_namespace_for_children } from '../../utils.js';
 import {
 	build_attribute_value,
@@ -147,7 +148,7 @@ export function SvelteElement(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([b.thunk(expression, true)]) : b.void0,
+					has_await ? b.array([async_thunk(expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$tag')] : [context.state.node],
 						b.block(statements)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/SvelteElement.js
@@ -148,7 +148,7 @@ export function SvelteElement(node, context) {
 					'$.async',
 					context.state.node,
 					node.metadata.expression.blockers(),
-					has_await ? b.array([async_thunk(expression)]) : b.void0,
+					has_await ? b.array([async_thunk(expression, node.metadata.expression)]) : b.void0,
 					b.arrow(
 						has_await ? [context.state.node, b.id('$$tag')] : [context.state.node],
 						b.block(statements)

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -206,9 +206,10 @@ export function VariableDeclaration(node, context) {
 			}
 
 			if (rune === '$derived' || rune === '$derived.by') {
-				const is_async = context.state.analysis.async_deriveds.has(
+				const metadata = context.state.analysis.async_deriveds.get(
 					/** @type {CallExpression} */ (init)
 				);
+				const is_async = metadata !== undefined;
 
 				if (declarator.id.type === 'Identifier') {
 					let expression = /** @type {Expression} */ (context.visit(value));
@@ -219,7 +220,7 @@ export function VariableDeclaration(node, context) {
 						/** @type {Expression} */
 						let call = b.call(
 							'$.async_derived',
-							async_thunk(expression),
+							async_thunk(expression, metadata),
 							dev && b.literal(declarator.id.name),
 							location ? b.literal(location) : undefined
 						);
@@ -252,7 +253,7 @@ export function VariableDeclaration(node, context) {
 
 							call = b.call(
 								'$.async_derived',
-								async_thunk(expression),
+								async_thunk(expression, metadata),
 								dev &&
 									b.literal(
 										`[$derived ${declarator.id.type === 'ArrayPattern' ? 'iterable' : 'object'}]`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -6,7 +6,13 @@ import { extract_paths, save } from '../../../../utils/ast.js';
 import * as b from '#compiler/builders';
 import * as assert from '../../../../utils/assert.js';
 import { get_rune } from '../../../scope.js';
-import { get_prop_source, is_prop_source, is_state_source, should_proxy } from '../utils.js';
+import {
+	async_thunk,
+	get_prop_source,
+	is_prop_source,
+	is_state_source,
+	should_proxy
+} from '../utils.js';
 import { get_value } from './shared/declarations.js';
 
 /**
@@ -213,7 +219,7 @@ export function VariableDeclaration(node, context) {
 						/** @type {Expression} */
 						let call = b.call(
 							'$.async_derived',
-							b.thunk(expression, true),
+							async_thunk(expression),
 							dev && b.literal(declarator.id.name),
 							location ? b.literal(location) : undefined
 						);
@@ -246,7 +252,7 @@ export function VariableDeclaration(node, context) {
 
 							call = b.call(
 								'$.async_derived',
-								b.thunk(expression, true),
+								async_thunk(expression),
 								dev &&
 									b.literal(
 										`[$derived ${declarator.id.type === 'ArrayPattern' ? 'iterable' : 'object'}]`

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -16,10 +16,10 @@ import { ExpressionMetadata } from '../../../../nodes.js';
  * from templates and replacing them with `$0`, `$1` etc
  */
 export class Memoizer {
-	/** @type {Array<{ id: Identifier, expression: Expression }>} */
+	/** @type {Array<{ id: Identifier, expression: Expression, metadata: ExpressionMetadata }>} */
 	#sync = [];
 
-	/** @type {Array<{ id: Identifier, expression: Expression }>} */
+	/** @type {Array<{ id: Identifier, expression: Expression, metadata: ExpressionMetadata }>} */
 	#async = [];
 
 	/** @type {Set<Expression>} */

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -43,7 +43,7 @@ export class Memoizer {
 
 		const id = b.id('#'); // filled in later
 
-		(metadata.has_await ? this.#async : this.#sync).push({ id, expression });
+		(metadata.has_await ? this.#async : this.#sync).push({ id, expression, metadata });
 
 		return id;
 	}
@@ -84,7 +84,7 @@ export class Memoizer {
 		if (this.#async.length === 0) return;
 		// use `b.arrow` rather than `b.thunk` so that deferred async/template effects
 		// always read live bindings rather than a possibly stale snapshot.
-		return b.array(this.#async.map((memo) => async_thunk(memo.expression)));
+		return b.array(this.#async.map((memo) => async_thunk(memo.expression, memo.metadata)));
 	}
 
 	sync_values() {

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/utils.js
@@ -8,7 +8,7 @@ import { sanitize_template_string } from '../../../../../utils/sanitize_template
 import { regex_is_valid_identifier } from '../../../../patterns.js';
 import is_reference from 'is-reference';
 import { dev, is_ignored, locator, component_name } from '../../../../../state.js';
-import { build_getter, is_state_source } from '../../utils.js';
+import { async_thunk, build_getter, is_state_source } from '../../utils.js';
 import { ExpressionMetadata } from '../../../../nodes.js';
 
 /**
@@ -84,7 +84,7 @@ export class Memoizer {
 		if (this.#async.length === 0) return;
 		// use `b.arrow` rather than `b.thunk` so that deferred async/template effects
 		// always read live bindings rather than a possibly stale snapshot.
-		return b.array(this.#async.map((memo) => b.arrow([], memo.expression, true)));
+		return b.array(this.#async.map((memo) => async_thunk(memo.expression)));
 	}
 
 	sync_values() {

--- a/packages/svelte/src/compiler/phases/nodes.js
+++ b/packages/svelte/src/compiler/phases/nodes.js
@@ -77,6 +77,9 @@ export class ExpressionMetadata {
 	/** True if the expression contains `await` */
 	has_await = false;
 
+	/** True if an `await` restores the reaction context afterwards, so the thunk must end it */
+	has_pickled_await = false;
+
 	/** True if the expression includes a member expression */
 	has_member_expression = false;
 
@@ -142,6 +145,7 @@ export class ExpressionMetadata {
 		this.has_state ||= source.has_state;
 		this.has_call ||= source.has_call;
 		this.has_await ||= source.has_await;
+		this.has_pickled_await ||= source.has_pickled_await;
 		this.has_member_expression ||= source.has_member_expression;
 		this.has_assignment ||= source.has_assignment;
 		this.#blockers = null; // so that blockers are recalculated

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -66,6 +66,8 @@ export interface Analysis {
 	async_deriveds: Set<CallExpression>;
 	/** Awaits needing context preservation */
 	pickled_awaits: Set<AwaitExpression>;
+	/** awaits inside reactive expressions, pickled or not — a restored context must end at each */
+	reactive_awaits: Set<AwaitExpression>;
 }
 
 export interface ComponentAnalysis extends Analysis {

--- a/packages/svelte/src/compiler/phases/types.d.ts
+++ b/packages/svelte/src/compiler/phases/types.d.ts
@@ -63,11 +63,9 @@ export interface Analysis {
 	accessors: boolean;
 
 	/** A set of deriveds that contain `await` expressions */
-	async_deriveds: Set<CallExpression>;
+	async_deriveds: Map<CallExpression, ExpressionMetadata>;
 	/** Awaits needing context preservation */
 	pickled_awaits: Set<AwaitExpression>;
-	/** awaits inside reactive expressions, pickled or not — a restored context must end at each */
-	reactive_awaits: Set<AwaitExpression>;
 }
 
 export interface ComponentAnalysis extends Analysis {

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -102,9 +102,8 @@ export {
 	for_await_track_reactivity_loss,
 	run,
 	save,
-	suspend,
 	track_reactivity_loss,
-	unset_restored_context,
+	unsave,
 	run_after_blockers,
 	wait
 } from './reactivity/async.js';

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -102,7 +102,9 @@ export {
 	for_await_track_reactivity_loss,
 	run,
 	save,
+	suspend,
 	track_reactivity_loss,
+	unset_restored_context,
 	run_after_blockers,
 	wait
 } from './reactivity/async.js';

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -156,6 +156,9 @@ export function capture() {
 	};
 }
 
+/** `true` between a `save` thunk restoring a context and the end of that synchronous segment */
+var restored = false;
+
 /**
  * Wraps an `await` expression in such a way that the effect context that was
  * active before the expression evaluated can be reapplied afterwards —
@@ -168,7 +171,7 @@ export async function save(promise) {
 	var restore = capture();
 	// the context restored by an earlier `save` in this expression must not
 	// outlive the synchronous segment that is about to end at this `await`
-	unset_restored_context();
+	unsave();
 	var value = await promise;
 
 	return () => {
@@ -178,27 +181,17 @@ export async function save(promise) {
 	};
 }
 
-/** `true` between a `save` thunk restoring a context and the end of that synchronous segment */
-var restored = false;
-
 /**
- * Unset the context if it was restored by a `save` thunk in the current synchronous
- * segment, so that a foreign microtask can never run inside a restored reaction context.
- * Called at every suspension point, and via `unsave` at the end of async expression bodies
- */
-function unset_restored_context() {
-	if (restored) unset_context();
-}
-
-/**
- * Ends the context restored by `save` when an async expression body completes —
+ * Unset the context if a `save` thunk restored it in the current synchronous segment,
+ * so that a foreign microtask can never run inside a restored reaction context.
+ * Called at every suspension point, and at the end of async expression bodies —
  * `async () => (await $.save(a))().b` becomes `async () => $.unsave((await $.save(a))().b)`
  * @template T
  * @param {T} [value]
  * @returns {T}
  */
 export function unsave(value) {
-	unset_restored_context();
+	if (restored) unset_context();
 	return /** @type {T} */ (value);
 }
 /**
@@ -209,7 +202,7 @@ export function unsave(value) {
  * @returns {Promise<() => T>}
  */
 export async function track_reactivity_loss(promise) {
-	unset_restored_context();
+	unsave();
 	var previous_reactivity_loss_tracker = reactivity_loss_tracker;
 	// Ensure that unrelated reads after an async operation is kicked off don't cause false positives
 	queueMicrotask(() => {

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -183,24 +183,23 @@ var restored = false;
 
 /**
  * Unset the context if it was restored by a `save` thunk in the current synchronous
- * segment. Called at every suspension point and at the end of async expression bodies,
- * so that a foreign microtask can never run inside a restored reaction context
+ * segment, so that a foreign microtask can never run inside a restored reaction context.
+ * Called at every suspension point, and via `unsave` at the end of async expression bodies
  */
-export function unset_restored_context() {
+function unset_restored_context() {
 	if (restored) unset_context();
 }
 
 /**
- * Production counterpart of `track_reactivity_loss` for awaits that need no
- * context preservation — `await b` becomes `await $.suspend(b)` so the
- * suspension still ends any restored context
+ * Ends the context restored by `save` when an async expression body completes —
+ * `async () => (await $.save(a))().b` becomes `async () => $.unsave((await $.save(a))().b)`
  * @template T
- * @param {T} value
+ * @param {T} [value]
  * @returns {T}
  */
-export function suspend(value) {
+export function unsave(value) {
 	unset_restored_context();
-	return value;
+	return /** @type {T} */ (value);
 }
 /**
  * Reset `current_async_effect` after the `promise` resolves, so

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -183,7 +183,7 @@ export async function save(promise) {
  * Unset the context if a `save` thunk restored it in the current synchronous segment,
  * so that a foreign microtask can never run inside a restored reaction context.
  * Called at every suspension point, and at the end of async expression bodies —
- * `async () => (await $.save(a))().b` becomes `async () => $.unsave((await $.save(a))().b)`
+ * `async () => (await $.save(a))().b` becomes `async () => { try { return (await $.save(a))().b; } finally { $.unsave(); } }`
  * @template T
  * @param {T} [value]
  * @returns {T}

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -8,7 +8,6 @@ import {
 	set_component_context,
 	set_dev_stack
 } from '../context.js';
-import { Boundary } from '../dom/blocks/boundary.js';
 import { invoke_error_boundary } from '../error-handling.js';
 import {
 	active_effect,
@@ -25,7 +24,6 @@ import {
 	set_reactivity_loss_tracker
 } from './deriveds.js';
 import { aborted } from './effects.js';
-import { queue_micro_task } from '../dom/task.js';
 
 /**
  * @param {Blocker[]} blockers
@@ -194,6 +192,7 @@ export function unsave(value) {
 	if (restored) unset_context();
 	return /** @type {T} */ (value);
 }
+
 /**
  * Reset `current_async_effect` after the `promise` resolves, so
  * that we can emit `await_reactivity_loss` warnings

--- a/packages/svelte/src/internal/client/reactivity/async.js
+++ b/packages/svelte/src/internal/client/reactivity/async.js
@@ -166,15 +166,42 @@ export function capture() {
  */
 export async function save(promise) {
 	var restore = capture();
+	// the context restored by an earlier `save` in this expression must not
+	// outlive the synchronous segment that is about to end at this `await`
+	unset_restored_context();
 	var value = await promise;
 
 	return () => {
 		restore();
-		queue_micro_task(unset_context);
+		restored = true;
 		return value;
 	};
 }
 
+/** `true` between a `save` thunk restoring a context and the end of that synchronous segment */
+var restored = false;
+
+/**
+ * Unset the context if it was restored by a `save` thunk in the current synchronous
+ * segment. Called at every suspension point and at the end of async expression bodies,
+ * so that a foreign microtask can never run inside a restored reaction context
+ */
+export function unset_restored_context() {
+	if (restored) unset_context();
+}
+
+/**
+ * Production counterpart of `track_reactivity_loss` for awaits that need no
+ * context preservation — `await b` becomes `await $.suspend(b)` so the
+ * suspension still ends any restored context
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+export function suspend(value) {
+	unset_restored_context();
+	return value;
+}
 /**
  * Reset `current_async_effect` after the `promise` resolves, so
  * that we can emit `await_reactivity_loss` warnings
@@ -183,6 +210,7 @@ export async function save(promise) {
  * @returns {Promise<() => T>}
  */
 export async function track_reactivity_loss(promise) {
+	unset_restored_context();
 	var previous_reactivity_loss_tracker = reactivity_loss_tracker;
 	// Ensure that unrelated reads after an async operation is kicked off don't cause false positives
 	queueMicrotask(() => {
@@ -269,6 +297,7 @@ export async function* for_await_track_reactivity_loss(iterable) {
 }
 
 export function unset_context(deactivate_batch = true) {
+	restored = false;
 	set_active_effect(null);
 	set_active_reaction(null);
 	set_component_context(null);

--- a/packages/svelte/tests/runtime-runes/samples/async-save-await-block-pending/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-await-block-pending/_config.js
@@ -1,0 +1,20 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, errors }) {
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		await tick();
+
+		assert.deepEqual(
+			errors.filter((error) => error.includes('state_unsafe_mutation')),
+			[]
+		);
+		assert.htmlEqual(target.innerHTML, '<p>pending</p><p>1</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-save-await-block-pending/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-await-block-pending/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	let foreign = $state(0);
+	const input = Promise.resolve({ pending: new Promise(() => {}) });
+
+	setTimeout(() => {
+		foreign += 1;
+	});
+</script>
+
+{#await (await input).pending}
+	<p>pending</p>
+{/await}
+
+<p>{foreign}</p>

--- a/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation-prod/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation-prod/_config.js
@@ -1,0 +1,22 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: false
+	},
+
+	async test({ assert, target, errors }) {
+		await tick();
+		await tick();
+		await tick();
+
+		assert.deepEqual(
+			errors.filter((error) => error.includes('state_unsafe_mutation')),
+			[]
+		);
+		assert.htmlEqual(target.innerHTML, '<p>4 1</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation-prod/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation-prod/main.svelte
@@ -1,0 +1,20 @@
+<script>
+	let foreign = $state(0);
+
+	const items = Promise.resolve([1, 2, 3]);
+	const one = Promise.resolve(1);
+
+	// lands the write while the derived is suspended on `await one`, after the
+	// context restored for `.length` — in production that await has no dev hook
+	items.then(() => {
+		queueMicrotask(() => {
+			queueMicrotask(() => {
+				foreign += 1;
+			});
+		});
+	});
+
+	const total = $derived((await items).length + (await one));
+</script>
+
+<p>{total} {foreign}</p>

--- a/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation/_config.js
@@ -1,0 +1,21 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, errors }) {
+		await tick();
+		await tick();
+
+		assert.deepEqual(
+			errors.filter((error) => error.includes('state_unsafe_mutation')),
+			[]
+		);
+		assert.htmlEqual(target.innerHTML, '<p>3 1</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-foreign-microtask-mutation/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let foreign = $state(0);
+
+	const items = Promise.resolve([1, 2, 3]);
+
+	// registered before the derived, so it runs first when `items` settles.
+	// Two nested microtasks land the write in the window between the compiled
+	// continuation restoring the derived's context and svelte's queued unset
+	items.then(() => {
+		queueMicrotask(() => {
+			queueMicrotask(() => {
+				foreign += 1;
+			});
+		});
+	});
+
+	// `.length` follows the await, so the compiler pickles it via `$.save`
+	const length = $derived((await items).length);
+</script>
+
+<p>{length} {foreign}</p>

--- a/packages/svelte/tests/runtime-runes/samples/async-save-throwing-expression/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-throwing-expression/_config.js
@@ -1,0 +1,20 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['client'],
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, errors }) {
+		await tick();
+		await tick();
+
+		assert.deepEqual(
+			errors.filter((error) => error.includes('state_unsafe_mutation')),
+			[]
+		);
+		assert.htmlEqual(target.innerHTML, '<p>failed</p><p>1</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/async-save-throwing-expression/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/async-save-throwing-expression/main.svelte
@@ -1,0 +1,26 @@
+<script>
+	let foreign = $state(0);
+	const input = Promise.resolve({
+		get value() {
+			throw new Error('boom');
+		}
+	});
+
+	input.then(() => {
+		queueMicrotask(() => {
+			queueMicrotask(() => {
+				foreign += 1;
+			});
+		});
+	});
+</script>
+
+<svelte:boundary onerror={() => {}}>
+	{#snippet failed()}
+		<p>failed</p>
+	{/snippet}
+
+	<p>{(await input).value}</p>
+</svelte:boundary>
+
+<p>{foreign}</p>

--- a/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
@@ -14,7 +14,7 @@ export default function Async_const($$anchor) {
 			let b;
 
 			var promises = $.run([
-				async () => $.suspend(a = (await $.save($.async_derived(async () => $.suspend((await $.save(1))()))))()),
+				async () => $.unsave(a = (await $.save($.async_derived(async () => $.unsave((await $.save(1))()))))()),
 				() => b = $.derived(() => $.get(a) + 1)
 			]);
 

--- a/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
@@ -14,7 +14,7 @@ export default function Async_const($$anchor) {
 			let b;
 
 			var promises = $.run([
-				async () => a = (await $.save($.async_derived(async () => (await $.save(1))())))(),
+				async () => $.suspend(a = (await $.save($.async_derived(async () => $.suspend((await $.save(1))()))))()),
 				() => b = $.derived(() => $.get(a) + 1)
 			]);
 

--- a/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-const/_expected/client/index.svelte.js
@@ -14,7 +14,19 @@ export default function Async_const($$anchor) {
 			let b;
 
 			var promises = $.run([
-				async () => $.unsave(a = (await $.save($.async_derived(async () => $.unsave((await $.save(1))()))))()),
+				async () => {
+					try {
+						return a = (await $.save($.async_derived(async () => {
+							try {
+								return (await $.save(1))();
+							} finally {
+								$.unsave();
+							}
+						})))();
+					} finally {
+						$.unsave();
+					}
+				},
 				() => b = $.derived(() => $.get(a) + 1)
 			]);
 

--- a/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
@@ -90,7 +90,7 @@ export default function Async_if_chain($$anchor) {
 
 	var node_3 = $.sibling(node_1, 2);
 
-	$.async(node_3, [$$promises[0]], [async () => (await $.save(foo))() > 10], (node_3, $$condition) => {
+	$.async(node_3, [$$promises[0]], [async () => $.suspend((await $.save(foo))() > 10)], (node_3, $$condition) => {
 		var consequent_5 = ($$anchor) => {
 			var text_7 = $.text('foo');
 
@@ -107,7 +107,7 @@ export default function Async_if_chain($$anchor) {
 			var fragment_2 = $.comment();
 			var node_4 = $.first_child(fragment_2);
 
-			$.async(node_4, [$$promises[0]], [async () => (await $.save(foo))() > 5], (node_4, $$condition) => {
+			$.async(node_4, [$$promises[0]], [async () => $.suspend((await $.save(foo))() > 5)], (node_4, $$condition) => {
 				var consequent_7 = ($$anchor) => {
 					var text_9 = $.text('baz');
 

--- a/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
@@ -90,7 +90,7 @@ export default function Async_if_chain($$anchor) {
 
 	var node_3 = $.sibling(node_1, 2);
 
-	$.async(node_3, [$$promises[0]], [async () => $.suspend((await $.save(foo))() > 10)], (node_3, $$condition) => {
+	$.async(node_3, [$$promises[0]], [async () => $.unsave((await $.save(foo))() > 10)], (node_3, $$condition) => {
 		var consequent_5 = ($$anchor) => {
 			var text_7 = $.text('foo');
 
@@ -107,7 +107,7 @@ export default function Async_if_chain($$anchor) {
 			var fragment_2 = $.comment();
 			var node_4 = $.first_child(fragment_2);
 
-			$.async(node_4, [$$promises[0]], [async () => $.suspend((await $.save(foo))() > 5)], (node_4, $$condition) => {
+			$.async(node_4, [$$promises[0]], [async () => $.unsave((await $.save(foo))() > 5)], (node_4, $$condition) => {
 				var consequent_7 = ($$anchor) => {
 					var text_9 = $.text('baz');
 

--- a/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-if-chain/_expected/client/index.svelte.js
@@ -90,52 +90,78 @@ export default function Async_if_chain($$anchor) {
 
 	var node_3 = $.sibling(node_1, 2);
 
-	$.async(node_3, [$$promises[0]], [async () => $.unsave((await $.save(foo))() > 10)], (node_3, $$condition) => {
-		var consequent_5 = ($$anchor) => {
-			var text_7 = $.text('foo');
+	$.async(
+		node_3,
+		[$$promises[0]],
+		[
+			async () => {
+				try {
+					return (await $.save(foo))() > 10;
+				} finally {
+					$.unsave();
+				}
+			}
+		],
+		(node_3, $$condition) => {
+			var consequent_5 = ($$anchor) => {
+				var text_7 = $.text('foo');
 
-			$.append($$anchor, text_7);
-		};
+				$.append($$anchor, text_7);
+			};
 
-		var consequent_6 = ($$anchor) => {
-			var text_8 = $.text('bar');
+			var consequent_6 = ($$anchor) => {
+				var text_8 = $.text('bar');
 
-			$.append($$anchor, text_8);
-		};
+				$.append($$anchor, text_8);
+			};
 
-		var alternate_4 = ($$anchor) => {
-			var fragment_2 = $.comment();
-			var node_4 = $.first_child(fragment_2);
+			var alternate_4 = ($$anchor) => {
+				var fragment_2 = $.comment();
+				var node_4 = $.first_child(fragment_2);
 
-			$.async(node_4, [$$promises[0]], [async () => $.unsave((await $.save(foo))() > 5)], (node_4, $$condition) => {
-				var consequent_7 = ($$anchor) => {
-					var text_9 = $.text('baz');
-
-					$.append($$anchor, text_9);
-				};
-
-				var alternate_3 = ($$anchor) => {
-					var text_10 = $.text('else');
-
-					$.append($$anchor, text_10);
-				};
-
-				$.if(
+				$.async(
 					node_4,
-					($$render) => {
-						if ($.get($$condition)) $$render(consequent_7); else $$render(alternate_3, -1);
-					},
-					true
+					[$$promises[0]],
+					[
+						async () => {
+							try {
+								return (await $.save(foo))() > 5;
+							} finally {
+								$.unsave();
+							}
+						}
+					],
+					(node_4, $$condition) => {
+						var consequent_7 = ($$anchor) => {
+							var text_9 = $.text('baz');
+
+							$.append($$anchor, text_9);
+						};
+
+						var alternate_3 = ($$anchor) => {
+							var text_10 = $.text('else');
+
+							$.append($$anchor, text_10);
+						};
+
+						$.if(
+							node_4,
+							($$render) => {
+								if ($.get($$condition)) $$render(consequent_7); else $$render(alternate_3, -1);
+							},
+							true
+						);
+					}
 				);
+
+				$.append($$anchor, fragment_2);
+			};
+
+			$.if(node_3, ($$render) => {
+				if ($.get($$condition)) $$render(consequent_5); else if (bar) $$render(consequent_6, 1); else $$render(alternate_4, -1);
 			});
-
-			$.append($$anchor, fragment_2);
-		};
-
-		$.if(node_3, ($$render) => {
-			if ($.get($$condition)) $$render(consequent_5); else if (bar) $$render(consequent_6, 1); else $$render(alternate_4, -1);
-		});
-	});
+		}
+	);
 
 	var node_5 = $.sibling(node_3, 2);
 

--- a/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
@@ -34,8 +34,8 @@ export default function Async_in_derived($$anchor, $$props) {
 			let no2;
 
 			var promises = $.run([
-				async () => yes1 = (await $.save($.async_derived(async () => (await $.save(1))())))(),
-				async () => yes2 = (await $.save($.async_derived(async () => foo((await $.save(1))()))))(),
+				async () => $.suspend(yes1 = (await $.save($.async_derived(async () => $.suspend((await $.save(1))()))))()),
+				async () => $.suspend(yes2 = (await $.save($.async_derived(async () => $.suspend(foo((await $.save(1))())))))()),
 				() => no1 = $.derived(() => (async () => {
 					return await 1;
 				})()),

--- a/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
@@ -34,8 +34,34 @@ export default function Async_in_derived($$anchor, $$props) {
 			let no2;
 
 			var promises = $.run([
-				async () => $.unsave(yes1 = (await $.save($.async_derived(async () => $.unsave((await $.save(1))()))))()),
-				async () => $.unsave(yes2 = (await $.save($.async_derived(async () => $.unsave(foo((await $.save(1))())))))()),
+				async () => {
+					try {
+						return yes1 = (await $.save($.async_derived(async () => {
+							try {
+								return (await $.save(1))();
+							} finally {
+								$.unsave();
+							}
+						})))();
+					} finally {
+						$.unsave();
+					}
+				},
+
+				async () => {
+					try {
+						return yes2 = (await $.save($.async_derived(async () => {
+							try {
+								return foo((await $.save(1))());
+							} finally {
+								$.unsave();
+							}
+						})))();
+					} finally {
+						$.unsave();
+					}
+				},
+
 				() => no1 = $.derived(() => (async () => {
 					return await 1;
 				})()),

--- a/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/async-in-derived/_expected/client/index.svelte.js
@@ -34,8 +34,8 @@ export default function Async_in_derived($$anchor, $$props) {
 			let no2;
 
 			var promises = $.run([
-				async () => $.suspend(yes1 = (await $.save($.async_derived(async () => $.suspend((await $.save(1))()))))()),
-				async () => $.suspend(yes2 = (await $.save($.async_derived(async () => $.suspend(foo((await $.save(1))())))))()),
+				async () => $.unsave(yes1 = (await $.save($.async_derived(async () => $.unsave((await $.save(1))()))))()),
+				async () => $.unsave(yes2 = (await $.save($.async_derived(async () => $.unsave(foo((await $.save(1))())))))()),
 				() => no1 = $.derived(() => (async () => {
 					return await 1;
 				})()),


### PR DESCRIPTION
When an async expression resumes after a pickled `await`, the thunk returned by `save()` in `reactivity/async.js` calls `restore()` to re-arm `active_reaction` for the rest of the expression, then disarms it with `queue_micro_task(unset_context)`. Any microtask already queued before that one runs inside the restored context. If it writes to a source, `set()` throws `state_unsafe_mutation` in production, since the guard is not dev-only. #18453 introduced the queued disarm and noted this case in review as unavoidable. SvelteKit hits it in practice: its fetch continuations write to internal `$state` (sveltejs/kit#16914), and a user's `$derived((await q()).length)` resuming in the same tick makes that write throw and drops the update signal.

The context restored by a `save` thunk now ends with the synchronous segment it was restored in. A `restored` flag is set by the thunk and consumed on entry to `save` and `track_reactivity_loss`, so every suspension ends it; once an expression contains a pickled await, the analysis pickles every later await in it too (`has_pickled_await` on `ExpressionMetadata`), so a trailing await compiles to `$.save` rather than a bare `await`. At the end of the body, `async_thunk` in `3-transform/client/utils.js` wraps the return expression in `$.unsave(...)` when the metadata has a pickled await. If the body throws instead, the context is unset by `async_derived`'s existing `finally`, as before. The queued microtask in `save` is removed.

Output is unchanged for expressions that pickle nothing (`$derived(await a)` compiles byte for byte the same). Expressions with a pickled await gain one `$.unsave(` call per body, and their trailing await becomes a `$.save`, 4 to 6 bytes gzipped in the added tests. At runtime a boolean write replaces a queued microtask per resume. `bench:compare` shows no difference outside run-to-run noise.

Two runtime tests reproduce the throw without any library involved, one in dev and one with the prod `await` shape, and fail on `main`.

