### PR TITLE
fix: remove `<svelte:head>` anchor on teardown

### DIFF
--- a/.changeset/tall-pandas-refuse.md
+++ b/.changeset/tall-pandas-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: remove `<svelte:head>` anchor on teardown instead of leaking one text node in `document.head` per mount

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-head.js
@@ -52,6 +52,17 @@ export function head(hash, render_fn) {
 		block(() => {
 			var e = branch(() => render_fn(anchor));
 			e.f |= HEAD_EFFECT;
+
+			// include the anchor in the effect's node range (content renders before
+			// it), so teardown removes it instead of leaking one text node in
+			// document.head per mount
+			if (anchor !== undefined) {
+				if (e.nodes === null) {
+					e.nodes = { start: anchor, end: anchor, a: null, t: null };
+				} else {
+					e.nodes.end = anchor;
+				}
+			}
 		});
 	} finally {
 		if (was_hydrating) {

--- a/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/Child.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/Child.svelte
@@ -1,0 +1,3 @@
+<svelte:head>
+	<meta content="value" name="test" />
+</svelte:head>

--- a/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const head = target.ownerDocument.head;
+		const initial = head.childNodes.length;
+		const button = target.querySelector('button');
+
+		// repeated mount/unmount must not accumulate anchor text nodes in <head>
+		for (let i = 0; i < 3; i++) {
+			button?.click();
+			flushSync();
+			button?.click();
+			flushSync();
+		}
+
+		assert.equal(head.childNodes.length, initial);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/head-anchor-cleanup/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	import Child from './Child.svelte';
+
+	let visible = $state(false);
+</script>
+
+<button onclick={() => (visible = !visible)}>toggle</button>
+
+{#if visible}
+	<Child />
+{/if}


### PR DESCRIPTION
Fixes #18695.

`head()` appends its text-node anchor to `document.head` before creating the head effect, so the anchor sits outside the branch effect's node range. Teardown removes the rendered head content (`HEAD_EFFECT` forces `remove_effect_dom`) but leaks the anchor — one empty text node in `document.head` per `<svelte:head>` mount, unbounded in SPAs (this appears to be the root cause of the symptom in sveltejs/kit#12405).

The fix includes the anchor in the branch's node range: head content renders contiguously before the anchor, so `remove_effect_dom(start, end)` (inclusive of `end`) sweeps it with the existing `HEAD_EFFECT` handling. During hydration `anchor` is `undefined` and behaviour is unchanged.

The added runtime test toggles a child with `<svelte:head>` three times and asserts `document.head.childNodes.length` returns to its initial value — it fails on `main` with `expected 3 to equal +0` (one leaked anchor per mount, in both dom and hydrate variants) and passes with this change. Full `runtime-runes` + `runtime-legacy` suites pass (6005 tests).

Independently verified in a large production SvelteKit app via a Playwright soak harness: DOM node growth on route ping-pong went from +2.03 nodes/loop (linear through 800 mounts, no plateau) to flat.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. If the feature is substantial or introduces breaking changes without a discussion, PR might be closed.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
