### PR TITLE
fix: track `SvelteDate` when read through `$state.snapshot`

### DIFF
--- a/.changeset/track-sveltedate-in-snapshot.md
+++ b/.changeset/track-sveltedate-in-snapshot.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: track `SvelteDate` when it is read through `$state.snapshot`

--- a/packages/svelte/src/internal/shared/clone.js
+++ b/packages/svelte/src/internal/shared/clone.js
@@ -105,7 +105,10 @@ function clone(value, cloned, path, paths, original = null, no_tojson = false) {
 		}
 
 		if (value instanceof Date) {
-			return /** @type {Snapshot<T>} */ (structuredClone(value));
+			// Read the time through the prototype rather than letting
+			// `structuredClone` read the internal slot, so that a reactive
+			// subclass like `SvelteDate` registers a dependency
+			return /** @type {Snapshot<T>} */ (new Date(value.getTime()));
 		}
 
 		if (typeof (/** @type {T & { toJSON?: any } } */ (value).toJSON) === 'function' && !no_tojson) {

--- a/packages/svelte/src/reactivity/date.test.ts
+++ b/packages/svelte/src/reactivity/date.test.ts
@@ -2,7 +2,7 @@ import { render_effect, effect_root } from '../internal/client/reactivity/effect
 import { flushSync } from '../index-client.js';
 import { SvelteDate } from './date.js';
 import { assert, test } from 'vitest';
-import { derived, get } from 'svelte/internal/client';
+import { derived, get, snapshot } from 'svelte/internal/client';
 
 const initial_date = new Date(2023, 0, 2, 0, 0, 0, 0);
 const a = new Date(2024, 1, 3, 1, 1, 1, 1);
@@ -669,6 +669,34 @@ test('Date methods shared between deriveds', () => {
 	});
 
 	assert.deepEqual(log, ['2023/2023', '2024/2024', '2025/2025']);
+
+	cleanup();
+});
+
+test('date is reactive when read through $state.snapshot', () => {
+	const date = new SvelteDate(initial_date);
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(snapshot(date).toISOString());
+		});
+	});
+
+	flushSync(() => {
+		date.setFullYear(a.getFullYear());
+	});
+
+	flushSync(() => {
+		date.setFullYear(b.getFullYear());
+	});
+
+	const after_a = new Date(initial_date);
+	after_a.setFullYear(a.getFullYear());
+	const after_b = new Date(initial_date);
+	after_b.setFullYear(b.getFullYear());
+
+	assert.deepEqual(log, [initial_date.toISOString(), after_a.toISOString(), after_b.toISOString()]);
 
 	cleanup();
 });


### PR DESCRIPTION
Fixes #18698

### Problem

`clone()` reaches the `value instanceof Date` branch before the `toJSON` branch, and `structuredClone` reads a Date's internal slot rather than going through the prototype. A `SvelteDate` therefore registers no dependency when read through `$state.snapshot`, so a reaction never re-runs when the date changes.

`SvelteMap` and `SvelteSet` are unaffected, because their branches copy by iteration and so go through the reactive machinery — which is what makes this look like an oversight rather than a deliberate asymmetry.

### Fix

Clone as `new Date(value.getTime())`. The read goes through the prototype, which is what makes the reactive subclass register a dependency, and the result is equivalent to `structuredClone` for a Date — invalid dates included, since `getTime()` returns `NaN` and `new Date(NaN)` is an Invalid Date.

Moving the `Date` branch after the `toJSON` branch would also fix it, but would be breaking: a plain `Date` would then snapshot to a string.

### Test plan

Added a case to `packages/svelte/src/reactivity/date.test.ts` that reads a `SvelteDate` through `snapshot()` inside a `render_effect` and asserts the effect re-runs on mutation. It fails on `main` — the log holds only the initial value — and passes with the fix.

Suites run locally:

- `src/reactivity` + `tests/snapshot` — 88 passed
- `tests/runtime-runes` — 2699 passed, 47 skipped
