### PR TITLE
fix: keep defaultChecked on hydrated radio inputs with spread attributes

### DIFF
--- a/.changeset/keep-radio-default-checked.md
+++ b/.changeset/keep-radio-default-checked.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep `defaultChecked` on hydrated radio inputs with spread attributes

--- a/packages/svelte/src/internal/client/dom/elements/attributes.js
+++ b/packages/svelte/src/internal/client/dom/elements/attributes.js
@@ -291,11 +291,8 @@ function set_attributes(
 	skip_warning = false
 ) {
 	if (hydrating && should_remove_defaults && element.nodeName === INPUT_TAG) {
-		var input = /** @type {HTMLInputElement} */ (element);
-		var attribute = input.type === 'checkbox' ? 'defaultChecked' : 'defaultValue';
-
-		if (!(attribute in next)) {
-			remove_input_defaults(input);
+		if (!('defaultValue' in next || 'defaultChecked' in next)) {
+			remove_input_defaults(/** @type {HTMLInputElement} */ (element));
 		}
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/form-default-checked-radio-spread/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/form-default-checked-radio-spread/_config.js
@@ -1,0 +1,23 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	mode: ['hydrate'],
+
+	async test({ assert, target }) {
+		const [a, b, reset] = target.querySelectorAll('input');
+
+		// let the deferred hydration cleanup run
+		await Promise.resolve();
+		flushSync();
+
+		b.checked = true;
+		reset.click();
+		await Promise.resolve();
+		flushSync();
+
+		assert.equal(a.defaultChecked, true);
+		assert.equal(a.checked, true);
+		assert.equal(b.checked, false);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/form-default-checked-radio-spread/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/form-default-checked-radio-spread/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let spread = { defaultChecked: true, checked: true };
+</script>
+
+<form>
+	<input type="radio" name="option" value="a" {...spread} />
+	<input type="radio" name="option" value="b" />
+	<input type="reset" value="Reset" />
+</form>


### PR DESCRIPTION
In `set_attributes` (`internal/client/dom/elements/attributes.js`), the hydration check that decides whether to call `remove_input_defaults` looks for `defaultChecked` in the spread only when `input.type === 'checkbox'`, and for `defaultValue` otherwise. A radio rendered with `{...{ defaultChecked: true, checked: true }}` therefore gets its SSR `checked` attribute removed in the deferred cleanup, after `element.defaultChecked = true` was already set, so a later `form.reset()` unchecks it. The compiler's non-spread path (`has_default_value_attribute` in `RegularElement.js`) already treats either `defaultValue` or `defaultChecked` as declared defaults for every input type; the spread path now uses the same condition.

Needed by sveltejs/kit#16926.
