### PR TITLE
fix: end a restored reactivity loss tracker at the end of its synchronous segment

### DIFF
--- a/.changeset/quiet-tracker-segment.md
+++ b/.changeset/quiet-tracker-segment.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: end a restored reactivity loss tracker at the end of its synchronous segment


### PR DESCRIPTION
Other half of #18694. That PR made the reaction context restored by a `save` thunk end with its synchronous segment. The DEV `reactivity_loss_tracker` restored by a `track_reactivity_loss` thunk in `reactivity/async.js` is still cleared with `queueMicrotask`, so a continuation queued before that microtask runs inside another expression's tracker window and `get()` warns `await_reactivity_loss` for a read that expression never made. sveltejs/kit#16914 is that shape, kit's fetch continuation reading its `_updated` state.

The thunk will mark the tracker as restored, `unsave()` will clear it as well, and in DEV every async body will end with `$.unsave(...)` whether or not it pickles. The queued clear goes away. Once this and #18694 are released, kit can raise its svelte floor and sveltejs/kit#16915 closes.
