### PR TITLE
fix: sync SvelteURL port when protocol setter clears it

### DIFF
--- a/.changeset/svelte-url-protocol-port.md
+++ b/.changeset/svelte-url-protocol-port.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: sync `SvelteURL` port signal when the protocol setter clears the port

--- a/packages/svelte/src/reactivity/url.js
+++ b/packages/svelte/src/reactivity/url.js
@@ -163,6 +163,8 @@ export class SvelteURL extends URL {
 	set protocol(value) {
 		super.protocol = value;
 		set(this.#protocol, super.protocol);
+		// changing the protocol can clear the port when it matches the new scheme's default
+		set(this.#port, super.port);
 	}
 
 	get search() {

--- a/packages/svelte/src/reactivity/url.test.ts
+++ b/packages/svelte/src/reactivity/url.test.ts
@@ -240,3 +240,25 @@ test('url.searchParams.forEach re-runs when the search string changes via the UR
 
 	cleanup();
 });
+
+test('url.port is updated when the protocol change clears the port', () => {
+	const url = new SvelteURL('http://example.com:443/');
+	const log: any = [];
+
+	const cleanup = effect_root(() => {
+		render_effect(() => {
+			log.push(url.port);
+		});
+	});
+
+	flushSync(() => {
+		// 443 is the default port for https, so it gets stripped
+		url.protocol = 'https:';
+	});
+
+	assert.equal(url.port, '');
+	assert.equal(url.href, 'https://example.com/');
+	assert.deepEqual(log, ['443', '']);
+
+	cleanup();
+});


### PR DESCRIPTION
## What

The `set protocol(value)` accessor on `SvelteURL` now resyncs the internal `#port` signal after mutating the protocol.

## Why

Per the WHATWG URL spec, assigning a new protocol can clear the URL's port when the current port equals the new scheme's default port. For example:

```js
const u = new URL('http://example.com:443/');
u.protocol = 'https:';
u.port; // '' (443 is https's default, so it is stripped)
```

`SvelteURL.set protocol` only updated the `#protocol` signal and left `#port` untouched. As a result:

- `url.port` returned the stale pre-assignment value (`'443'` instead of `''`).
- Any `$effect`/`$derived` subscribed to `url.port` was never re-run even though the real port changed.

This was inconsistent with `set host` (which updates both hostname and port) and `set href` (which updates all component signals).

## How

Add `set(this.#port, super.port)` alongside the existing protocol sync. `internal_set` only notifies when the value actually changes, so this is a no-op when the port is unaffected.

## Tests

Added a regression test in `packages/svelte/src/reactivity/url.test.ts` that subscribes an effect to `url.port`, changes the protocol so the default port is stripped, and asserts both the value (`url.port === ''`, matching native `URL`) and the reactive log (`['443', '']`). The test fails before the fix (port stays `'443'`) and passes after.