### PR TITLE
fix: prevent derived store glitches with 32 or more dependencies

### DIFF
--- a/.changeset/store-derived-bitmask.md
+++ b/.changeset/store-derived-bitmask.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent `derived` store glitches with 32 or more dependencies

--- a/packages/svelte/src/store/shared/index.js
+++ b/packages/svelte/src/store/shared/index.js
@@ -139,6 +139,8 @@ export function derived(stores, fn, initial_value) {
 		/** @type {T[]} */
 		const values = [];
 		let pending = 0;
+		/** @type {boolean[]} */
+		const dirty = [];
 		let cleanup = noop;
 		const sync = () => {
 			if (pending) {
@@ -157,13 +159,19 @@ export function derived(stores, fn, initial_value) {
 				store,
 				(value) => {
 					values[i] = value;
-					pending &= ~(1 << i);
+					if (dirty[i]) {
+						dirty[i] = false;
+						pending--;
+					}
 					if (started) {
 						sync();
 					}
 				},
 				() => {
-					pending |= 1 << i;
+					if (!dirty[i]) {
+						dirty[i] = true;
+						pending++;
+					}
 				}
 			)
 		);

--- a/packages/svelte/tests/store/test.ts
+++ b/packages/svelte/tests/store/test.ts
@@ -397,6 +397,36 @@ describe('derived', () => {
 		unsubscribe();
 	});
 
+	it('prevents diamond dependency problem with 32 or more dependencies', () => {
+		const count = writable(0);
+
+		const values: string[] = [];
+
+		// the shared ancestor feeds two dependencies placed at indices 0 and 32,
+		// which alias each other in a 32-bit dirty bitmask (1 << 32 === 1 << 0)
+		const first = derived(count, ($count) => $count);
+		const last = derived(count, ($count) => $count * 100);
+
+		const stores: Readable<any>[] = [first];
+		for (let i = 1; i < 32; i += 1) {
+			stores.push(readable(0));
+		}
+		stores.push(last);
+
+		const combined = derived(stores, (deps) => `${deps[0]}/${deps[32]}`);
+
+		const unsubscribe = combined.subscribe((v) => {
+			values.push(v as string);
+		});
+
+		assert.deepEqual(values, ['0/0']);
+
+		count.set(1);
+		assert.deepEqual(values, ['0/0', '1/100']);
+
+		unsubscribe();
+	});
+
 	it('derived dependency does not update and shared ancestor updates', () => {
 		const root = writable({ a: 0, b: 0 });
 


### PR DESCRIPTION
## What

The store `derived([...])` glitch-prevention mechanism no longer breaks when a derived has 32 or more dependencies.

## Why

`derived()` uses a per-dependency "dirty" tracker so it defers recomputation until every invalidated dependency has delivered its new value (glitch prevention). Previously this was a single 32-bit integer bitmask:

```js
pending |= 1 << i;   // invalidate
pending &= ~(1 << i); // value delivered
```

JS bitwise operators coerce their operands to 32-bit integers, so `1 << i` wraps for `i >= 32` (`1 << 32 === 1`, `1 << 33 === 2`, ...). Dependencies at index 32 and beyond therefore alias lower-index dependencies in the bitmask. When two aliased dependencies invalidate in the same propagation flush (e.g. they share a common ancestor store), delivering the value for the lower-index one prematurely clears the pending flag for the higher-index one, so the derived recomputes with a stale value and emits an intermediate glitched value that a correct implementation never produces.

## How

Replace the fixed-width bitmask with a counter plus per-index dirty flags. This preserves the exact semantics for small dependency counts and is correct for any number of dependencies.

## Tests

Added a case in `packages/svelte/tests/store/test.ts` mirroring the existing "prevents diamond dependency problem" test but with 33 dependencies, where the two stores derived from a shared ancestor sit at indices 0 and 32 (which alias in a 32-bit mask). It asserts no intermediate glitched value is emitted. The test fails before the fix (an extra `'1/0'` value appears) and passes after.