### PR TITLE
fix: don't flag stable NaN keys as volatile in each idempotency check

### DIFF
--- a/.changeset/each-key-nan.md
+++ b/.changeset/each-key-nan.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't flag stable `NaN` keys as volatile in dev `{#each}` idempotency check

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -306,7 +306,7 @@ export function each(node, flags, get_collection, get_key, render_fn, fallback_f
 			if (DEV) {
 				// Check that the key function is idempotent (returns the same value when called twice)
 				var key_again = get_key(value, index);
-				if (key !== key_again) {
+				if (!Object.is(key, key_again)) {
 					e.each_key_volatile(String(index), String(key), String(key_again));
 				}
 			}

--- a/packages/svelte/tests/runtime-runes/samples/each-key-nan/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-key-nan/_config.js
@@ -1,0 +1,13 @@
+import { test } from '../../test';
+
+// a deterministic `NaN` key is idempotent (`NaN !== NaN`, but `Object.is(NaN, NaN)`),
+// so the dev-mode key-idempotency check must not throw `each_key_volatile`
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	mode: ['client'],
+
+	html: `<p>NaN</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-key-nan/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-key-nan/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let things = $state([{ id: NaN }]);
+</script>
+
+{#each things as thing (thing.id)}
+	<p>{thing.id}</p>
+{/each}


### PR DESCRIPTION
## What

The dev-mode `{#each}` key-idempotency guard no longer throws `each_key_volatile` for key functions that deterministically return `NaN`.

## Why

In DEV mode, the `{#each}` block verifies that the key function is idempotent by calling it twice and comparing the results:

```js
var key_again = get_key(value, index);
if (key !== key_again) {
  e.each_key_volatile(...);
}
```

When the key is `NaN`, `NaN !== NaN` is always `true`, so a genuinely idempotent key function is misclassified as volatile and the component crashes in development with `each_key_volatile`.

## How

Use `Object.is(key, key_again)` instead of `!==`. `Object.is(NaN, NaN)` is `true`, eliminating the false positive, while distinct fresh array/object references still compare as not-same, preserving the intended volatile-key detection.

## Tests

Added a runtime-runes sample `each-key-nan` (`compileOptions.dev = true`) that renders a keyed each whose key is `NaN` and asserts it renders without error. The test throws `each_key_volatile` before the fix and passes after. The existing `each-key-volatile` sample (which uses fresh array keys) still throws as expected, guarding against regressions.