### PR TITLE
fix: decode uppercase-X hex numeric character references

### DIFF
--- a/.changeset/uppercase-hex-entities.md
+++ b/.changeset/uppercase-hex-entities.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: decode uppercase-`X` hex numeric character references (`&#X...;`)

--- a/packages/svelte/src/compiler/phases/1-parse/utils/html.js
+++ b/packages/svelte/src/compiler/phases/1-parse/utils/html.js
@@ -20,7 +20,7 @@ function reg_exp_entity(entity_name, is_attribute_value) {
 
 /** @param {boolean} is_attribute_value */
 function get_entity_pattern(is_attribute_value) {
-	const reg_exp_num = '#(?:x[a-fA-F\\d]+|\\d+)(?:;)?';
+	const reg_exp_num = '#(?:[xX][a-fA-F\\d]+|\\d+)(?:;)?';
 	const reg_exp_entities = Object.keys(entities).map(
 		/** @param {any} entity_name */ (entity_name) => reg_exp_entity(entity_name, is_attribute_value)
 	);
@@ -50,7 +50,7 @@ export function decode_character_references(html, is_attribute_value) {
 			// Handle named entities
 			if (entity[0] !== '#') {
 				code = entities[entity];
-			} else if (entity[1] === 'x') {
+			} else if (entity[1] === 'x' || entity[1] === 'X') {
 				code = parseInt(entity.substring(2), 16);
 			} else {
 				code = parseInt(entity.substring(1), 10);

--- a/packages/svelte/tests/runtime-legacy/samples/html-entities/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/html-entities/_config.js
@@ -7,6 +7,7 @@ export default test({
 		<span>*</span>
 		<span>*</span>
 		<span>*</span>
+		<span>*</span>
 
 		<span></span>
 		<span>A</span>

--- a/packages/svelte/tests/runtime-legacy/samples/html-entities/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/html-entities/main.svelte
@@ -2,6 +2,7 @@
 <span>&midast;</span>
 <span>&#x0002A;</span>
 <span>&#x0002A</span>
+<span>&#X0002A;</span>
 <span>&#42;</span>
 
 <span>&#10;</span>


### PR DESCRIPTION
## What

Hex numeric character references introduced by an uppercase `X` (e.g. `&#X41;`, `&#X0002A;`) are now decoded, matching the existing lowercase `x` handling.

## Why

Per the HTML spec (numeric character reference state), **both** `x` (U+0078) and `X` (U+0058) are valid prefixes for a hexadecimal reference. Svelte's decoder only recognized the lowercase form in two places:

- the entity-matching regex `#(?:x[a-fA-F\d]+|\d+)(?:;)?` only permits `x`, so `&#X41;` never matches the numeric alternative and is left as literal text;
- the decode branch `else if (entity[1] === 'x')` would also miss `X`.

So uppercase-`X` references were silently rendered as raw text instead of the intended character.

## How

- Broaden the regex character class to `[xX]`.
- Broaden the decode branch to `entity[1] === 'x' || entity[1] === 'X'` so `parseInt(entity.substring(2), 16)` runs for both forms.

## Tests

Added `<span>&#X0002A;</span>` (expected `*`) to the existing `runtime-legacy/samples/html-entities` sample, alongside the lowercase `&#x0002A;` case. It renders as literal `&#X0002A;` before the fix and as `*` after.