### PR TITLE
fix: clear last scheduled effect in destroy_effect to prevent detached subtree leaks (#18623)

### DIFF
--- a/.changeset/fix-destroy-effect-leak.md
+++ b/.changeset/fix-destroy-effect-leak.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: clear last scheduled effect reference in `destroy_effect` to prevent detached subtree memory leaks (#18623)

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -69,6 +69,16 @@ export let batch_values = null;
 /** @type {Effect | null} */
 let last_scheduled_effect = null;
 
+/**
+ * @param {Effect} effect
+ * @returns {void}
+ */
+export function clear_last_scheduled_effect(effect) {
+	if (last_scheduled_effect === effect) {
+		last_scheduled_effect = null;
+	}
+}
+
 export let is_flushing_sync = false;
 let is_processing = false;
 

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -41,7 +41,7 @@ import { DEV } from 'esm-env';
 import { define_property } from '../../shared/utils.js';
 import { get_next_sibling } from '../dom/operations.js';
 import { component_context, dev_current_component_function, dev_stack } from '../context.js';
-import { Batch, collected_effects, current_batch } from './batch.js';
+import { Batch, clear_last_scheduled_effect, collected_effects, current_batch } from './batch.js';
 import { flatten } from './async.js';
 import { without_reactive_context } from '../dom/elements/bindings/shared.js';
 import { set_signal_status } from './status.js';
@@ -547,6 +547,8 @@ export function destroy_effect(effect, remove_dom = true) {
 	if (DEV) {
 		effect.component_function = null;
 	}
+
+	clear_last_scheduled_effect(effect);
 
 	// `first` and `child` are nulled out in destroy_effect_children
 	// we don't null out `parent` so that error propagation can work correctly

--- a/packages/svelte/tests/signals/test.ts
+++ b/packages/svelte/tests/signals/test.ts
@@ -1521,4 +1521,25 @@ describe('signals', () => {
 			assert.equal(s.reactions, null);
 		};
 	});
+
+	test('destroy_effect clears scheduling and effect state (#18623)', () => {
+		return () => {
+			let s = state(0);
+			let e: Effect | undefined;
+
+			let destroy = effect_root(() => {
+				e = effect(() => {
+					$.get(s);
+				});
+			});
+
+			set(s, 1);
+			flushSync();
+
+			destroy();
+
+			assert.equal(e?.deps, null);
+			assert.equal(e?.fn, null);
+		};
+	});
 });


### PR DESCRIPTION
Fixes #18623

### Description
In Svelte 5 reactivity runtime, \last_scheduled_effect\ held a reference to the last effect scheduled in module scope indefinitely until flushed. When component subtrees were destroyed/unmounted, this retained references to detached DOM nodes and component context, causing a memory leak.

### Fix
- Added \clear_last_scheduled_effect(effect)\ in \packages/svelte/src/internal/client/reactivity/batch.js\.
- Called \clear_last_scheduled_effect(effect)\ in \destroy_effect()\ inside \packages/svelte/src/internal/client/reactivity/effects.js\.
- Added test in \packages/svelte/tests/signals/test.ts\.
- Added changeset file.