### PR TITLE
fix: render `selected` options for `<select multiple>` with an array `value` on the server

### DIFF
--- a/.changeset/ssr-select-multiple-array.md
+++ b/.changeset/ssr-select-multiple-array.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: render `selected` options for `<select multiple>` with an array `value` on the server

--- a/.changeset/ssr-select-multiple-array.md
+++ b/.changeset/ssr-select-multiple-array.md
@@ -1,5 +1,0 @@
----
-'svelte': patch
----
-
-fix: render `selected` options for `<select multiple>` with an array `value` on the server

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -89,7 +89,7 @@ export class Renderer {
 	 * State that is local to the branch it is declared in.
 	 * It will be shallow-copied to all children.
 	 *
-	 * @type {{ select_value: any, select_default_multiple: boolean }}
+	 * @type {{ select_value: any }}
 	 */
 	local;
 
@@ -101,9 +101,7 @@ export class Renderer {
 		this.#parent = parent;
 
 		this.global = global;
-		this.local = parent
-			? { ...parent.local }
-			: { select_value: undefined, select_default_multiple: false };
+		this.local = parent ? { ...parent.local } : { select_value: undefined };
 		this.type = parent ? parent.type : 'body';
 	}
 
@@ -346,8 +344,6 @@ export class Renderer {
 		this.push(`<select${attributes(select_attrs, css_hash, classes, styles, flags)}>`);
 		this.child((renderer) => {
 			renderer.local.select_value = value === undefined ? defaultValue : value;
-			renderer.local.select_default_multiple =
-				value === undefined && Boolean(select_attrs.multiple);
 			fn(renderer);
 		});
 		this.push(`${is_rich ? '<!>' : ''}</select>`);
@@ -375,11 +371,9 @@ export class Renderer {
 				value = attrs.value;
 			}
 
-			if (
-				this.local.select_default_multiple
-					? is_array(this.local.select_value) && this.local.select_value.includes(value)
-					: value === this.local.select_value
-			) {
+			var select_value = this.local.select_value;
+
+			if (is_array(select_value) ? select_value.includes(value) : value === select_value) {
 				renderer.#out.push(' selected=""');
 			}
 

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -89,7 +89,7 @@ export class Renderer {
 	 * State that is local to the branch it is declared in.
 	 * It will be shallow-copied to all children.
 	 *
-	 * @type {{ select_value: any }}
+	 * @type {{ select_value: any, multiple: boolean }}
 	 */
 	local;
 
@@ -101,7 +101,7 @@ export class Renderer {
 		this.#parent = parent;
 
 		this.global = global;
-		this.local = parent ? { ...parent.local } : { select_value: undefined };
+		this.local = parent ? { ...parent.local } : { select_value: undefined, multiple: false };
 		this.type = parent ? parent.type : 'body';
 	}
 
@@ -344,6 +344,7 @@ export class Renderer {
 		this.push(`<select${attributes(select_attrs, css_hash, classes, styles, flags)}>`);
 		this.child((renderer) => {
 			renderer.local.select_value = value === undefined ? defaultValue : value;
+			renderer.local.multiple = !!select_attrs.multiple;
 			fn(renderer);
 		});
 		this.push(`${is_rich ? '<!>' : ''}</select>`);
@@ -373,7 +374,13 @@ export class Renderer {
 
 			var select_value = this.local.select_value;
 
-			if (is_array(select_value) ? select_value.includes(value) : value === select_value) {
+			if (
+				// Super edge-case, but theoretically someone could use arrays with non-multiple selects,
+				// so we gotta check for the multiple attribute presence, too.
+				this.local.multiple && is_array(select_value)
+					? select_value.includes(value)
+					: value === select_value
+			) {
 				renderer.#out.push(' selected=""');
 			}
 

--- a/packages/svelte/tests/runtime-legacy/samples/binding-select-multiple/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/binding-select-multiple/_config.js
@@ -6,17 +6,30 @@ export default test({
 		return { selected: ['two', 'three'] };
 	},
 
-	html: `
+	ssrHtml: `
 		<select multiple>
 			<option>one</option>
-			<option>two</option>
-			<option>three</option>
+			<option selected>two</option>
+			<option selected>three</option>
 		</select>
 
 		<p>selected: two, three</p>
 	`,
 
-	test({ assert, component, target, window }) {
+	test({ assert, component, target, window, variant }) {
+		const selected = variant === 'hydrate' ? ' selected' : '';
+		assert.htmlEqual(
+			target.innerHTML,
+			`
+			<select multiple>
+				<option>one</option>
+				<option${selected}>two</option>
+				<option${selected}>three</option>
+			</select>
+
+			<p>selected: two, three</p>
+		`
+		);
 		const select = target.querySelector('select');
 		ok(select);
 		const options = [...target.querySelectorAll('option')];
@@ -33,8 +46,8 @@ export default test({
 			`
 			<select multiple>
 				<option>one</option>
-				<option>two</option>
-				<option>three</option>
+				<option${selected}>two</option>
+				<option${selected}>three</option>
 			</select>
 
 			<p>selected: three</p>
@@ -51,8 +64,8 @@ export default test({
 			`
 			<select multiple>
 				<option>one</option>
-				<option>two</option>
-				<option>three</option>
+				<option${selected}>two</option>
+				<option${selected}>three</option>
 			</select>
 
 			<p>selected: one, three</p>
@@ -70,8 +83,8 @@ export default test({
 			`
 			<select multiple>
 				<option>one</option>
-				<option>two</option>
-				<option>three</option>
+				<option${selected}>two</option>
+				<option${selected}>three</option>
 			</select>
 
 			<p>selected: one, two</p>

--- a/packages/svelte/tests/server-side-rendering/samples/select-multiple-value/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/select-multiple-value/_expected.html
@@ -1,0 +1,5 @@
+<select multiple="">
+	<option selected="" value="a">A</option>
+	<option value="b">B</option>
+	<option selected="" value="c">C</option>
+</select>

--- a/packages/svelte/tests/server-side-rendering/samples/select-multiple-value/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/select-multiple-value/main.svelte
@@ -1,0 +1,5 @@
+<select multiple value={['a', 'c']}>
+	<option value="a">A</option>
+	<option value="b">B</option>
+	<option value="c">C</option>
+</select>


### PR DESCRIPTION
`<select multiple value={['a', 'c']}>` and `bind:value` with an array now render `selected` on the matching options, so server output matches what the client selects after hydration instead of showing nothing selected until then.

`Renderer.option` in `internal/server/renderer.js` compared each option value with `===` against `local.select_value`, which for a multiple select is the array itself, so nothing matched. #18591 added a `select_default_multiple` flag that switches to `includes`, but only when the value came from `defaultValue`.

The flag is gone, `option` checks `is_array(select_value) ? select_value.includes(value) : value === select_value`. `binding-select-multiple` gets an `ssrHtml` since the server output changed.

Follow-up to #18591.
