### PR TITLE
fix: keep boolean attributes with an empty string value when rendering attribute objects on the server

### DIFF
--- a/.changeset/ssr-empty-boolean-attribute.md
+++ b/.changeset/ssr-empty-boolean-attribute.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep boolean attributes with an empty string value when rendering attribute objects on the server

--- a/packages/svelte/src/internal/shared/attributes.js
+++ b/packages/svelte/src/internal/shared/attributes.js
@@ -27,7 +27,8 @@ export function attr(name, value, is_boolean = false) {
 	if (name === 'hidden' && value !== 'until-found') {
 		is_boolean = true;
 	}
-	if (value == null || (!value && is_boolean)) return '';
+	// `''` is a present boolean attribute, as it is in markup and on the client
+	if (value == null || (is_boolean && !value && value !== '')) return '';
 	const normalized =
 		(has_own_property.call(replacements, name) && replacements[name].get(value)) || value;
 	const assignment = is_boolean ? `=""` : `="${escape_html(normalized, true)}"`;

--- a/packages/svelte/tests/server-side-rendering/samples/empty-boolean-attribute-object/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/empty-boolean-attribute-object/_expected.html
@@ -1,0 +1,6 @@
+<input disabled="">
+<input hidden="">
+<input>
+<select multiple="">
+	<option selected="" value="a">A</option>
+</select>

--- a/packages/svelte/tests/server-side-rendering/samples/empty-boolean-attribute-object/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/empty-boolean-attribute-object/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	const props = {};
+</script>
+
+<input disabled="" {...props} />
+<input hidden="" {...props} />
+<input disabled={false} {...props} />
+<select multiple="" value="a">
+	<option value="a">A</option>
+</select>


### PR DESCRIPTION
`<input disabled="" {...props}>` and any other boolean attribute written as `""` now renders on the server the way it does on the client and in plain markup.

`attr` in `internal/shared/attributes.js` drops a boolean attribute when its value is falsy, and `""` is falsy, so once an element's attributes go through the object path (a spread, or the `<select>`/`<option>` special casing) `disabled=""`, `hidden=""` or `multiple=""` vanish from the output. The client's `set_attributes` sets them, so the two disagree until hydration. #18591 worked around it for `multiple` on `<select>` only.

`attr` keeps `""` for boolean attributes and still drops `null`, `undefined`, `false` and `0`.
