### PR TITLE
perf: skip the anchor comment for a lone dynamic component

### DIFF
--- a/.changeset/lazy-poems-shave.md
+++ b/.changeset/lazy-poems-shave.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+perf: render a lone dynamic component into its parent block's anchor

--- a/packages/svelte/src/compiler/phases/3-transform/utils.js
+++ b/packages/svelte/src/compiler/phases/3-transform/utils.js
@@ -280,6 +280,8 @@ export function clean_nodes(
 		/**
 		 * In a case like `{#if x}<Foo />{/if}`, we don't need to wrap the child in
 		 * comments — we can just use the parent block's anchor for the component.
+		 * This applies to dynamic components too; `$.component` claims the DOM boundary
+		 * and steps over the closing hydration marker itself when there is no anchor.
 		 * TODO extend this optimisation to other cases
 		 */
 		is_standalone:
@@ -287,7 +289,6 @@ export function clean_nodes(
 			((first.type === 'RenderTag' && !first.metadata.dynamic) ||
 				(first.type === 'Component' &&
 					!state.options.hmr &&
-					!first.metadata.dynamic &&
 					!first.attributes.some(
 						(attribute) => attribute.type === 'Attribute' && attribute.name.startsWith('--')
 					))),

--- a/packages/svelte/src/internal/client/dom/blocks/each.js
+++ b/packages/svelte/src/internal/client/dom/blocks/each.js
@@ -29,6 +29,7 @@ import {
 	block,
 	branch,
 	destroy_effect,
+	get_effect_nodes,
 	move_effect,
 	pause_effect,
 	resume_effect
@@ -707,14 +708,15 @@ function create_item(items, anchor, value, key, index, render_fn, flags, get_col
  * @param {Text | Element | Comment} anchor
  */
 function move(effect, next, anchor) {
-	if (!effect.nodes) return;
+	var nodes = get_effect_nodes(effect);
+	if (nodes === null) return;
 
-	var node = effect.nodes.start;
-	var end = effect.nodes.end;
+	var node = nodes.start;
+	var end = nodes.end;
 
 	var dest =
 		next && (next.f & EFFECT_OFFSCREEN) === 0
-			? /** @type {EffectNodes} */ (next.nodes).start
+			? /** @type {EffectNodes} */ (get_effect_nodes(next)).start
 			: anchor;
 
 	while (node !== null) {

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,4 +1,4 @@
-/** @import { TemplateNode, Dom } from '#client' */
+/** @import { Effect, TemplateNode, Dom } from '#client' */
 import { EFFECT_TRANSPARENT } from '#client/constants';
 import { block } from '../../reactivity/effects.js';
 import {
@@ -10,6 +10,8 @@ import {
 	set_hydrating,
 	skip_nodes
 } from '../hydration.js';
+import { active_effect } from '../../runtime.js';
+import { assign_nodes } from '../template.js';
 import { BranchManager } from './branches.js';
 import { HYDRATION_START, HYDRATION_START_ELSE } from '../../../../constants.js';
 
@@ -58,4 +60,13 @@ export function component(node, get_component, render_fn) {
 
 		branches.ensure(component, component && ((target) => render_fn(target, component)));
 	}, EFFECT_TRANSPARENT);
+
+	// If no anchor comment was created for this block — i.e. it is the sole child of its
+	// parent and renders straight into the parent's anchor — then nothing else will claim
+	// the DOM boundary or step over the closing hydration marker, so do both here.
+	// Otherwise the enclosing `$.append` does it.
+	if (hydrating && /** @type {Effect} */ (active_effect).nodes === null) {
+		assign_nodes(/** @type {TemplateNode} */ (hydration_start_node), hydrate_node);
+		hydrate_next();
+	}
 }

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -1,4 +1,4 @@
-/** @import { Blocker, ComponentContext, ComponentContextLegacy, Derived, Effect, TemplateNode, TransitionManager } from '#client' */
+/** @import { Blocker, ComponentContext, ComponentContextLegacy, Derived, Effect, EffectNodes, TemplateNode, TransitionManager } from '#client' */
 import {
 	is_dirty,
 	active_effect,
@@ -567,6 +567,37 @@ export function destroy_effect(effect, remove_dom = true) {
 		effect.ac =
 		effect.b =
 			null;
+}
+
+/**
+ * Returns the DOM boundary of an effect. An effect whose only content is a block — for
+ * example an `{#each}` item or `{#if}` branch whose sole child is a dynamic component —
+ * has no `nodes` of its own, because the DOM belongs to the block's branch. Derive the
+ * boundary from its children in that case.
+ * @param {Effect} effect
+ * @returns {EffectNodes | null}
+ */
+export function get_effect_nodes(effect) {
+	if (effect.nodes !== null) return effect.nodes;
+
+	/** @type {EffectNodes | null} */
+	var first = null;
+
+	/** @type {EffectNodes | null} */
+	var last = null;
+
+	for (var child = effect.first; child !== null; child = child.next) {
+		var nodes = get_effect_nodes(child);
+		if (nodes === null) continue;
+
+		first ??= nodes;
+		last = nodes;
+	}
+
+	if (first === null) return null;
+	if (first === last) return first;
+
+	return { start: first.start, end: /** @type {EffectNodes} */ (last).end, a: null, t: null };
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -773,11 +773,12 @@ export function aborted(effect = /** @type {Effect} */ (active_effect)) {
  * @param {DocumentFragment} fragment
  */
 export function move_effect(effect, fragment) {
-	if (!effect.nodes) return;
+	var nodes = get_effect_nodes(effect);
+	if (nodes === null) return;
 
 	/** @type {TemplateNode | null} */
-	var node = effect.nodes.start;
-	var end = effect.nodes.end;
+	var node = nodes.start;
+	var end = nodes.end;
 
 	while (node !== null) {
 		/** @type {TemplateNode | null} */

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/A.svelte
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/A.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { item } = $props();
+</script>
+
+<span>{item}</span>

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/client/A.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/client/A.svelte.js
@@ -1,0 +1,12 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+
+var root = $.from_html(`<span> </span>`);
+
+export default function A($$anchor, $$props) {
+	var span = root();
+	var text = $.only_child(span, true);
+
+	$.template_effect(() => $.set_text(text, $$props.item));
+	$.append($$anchor, span);
+}

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/client/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/client/index.svelte.js
@@ -1,0 +1,43 @@
+import 'svelte/internal/disclose-version';
+import * as $ from 'svelte/internal/client';
+import A from './A.svelte';
+
+var root = $.from_html(`<!><span></span>`, 1);
+var root_1 = $.from_html(`<!> <!>`, 1);
+
+export default function Lone_dynamic_component($$anchor) {
+	let Component = $.proxy(A);
+	let items = $.proxy([1, 2, 3]);
+	var fragment = root_1();
+	var node = $.first_child(fragment);
+
+	$.each(node, 17, () => items, $.index, ($$anchor, item) => {
+		$.component($$anchor, () => Component, ($$anchor, Component_1) => {
+			Component_1($$anchor, {
+				get item() {
+					return $.get(item);
+				}
+			});
+		});
+	});
+
+	var node_1 = $.sibling(node, 2);
+
+	$.each(node_1, 17, () => items, $.index, ($$anchor, item) => {
+		var fragment_2 = root();
+		var node_2 = $.first_child(fragment_2);
+
+		$.component(node_2, () => Component, ($$anchor, Component_2) => {
+			Component_2($$anchor, {
+				get item() {
+					return $.get(item);
+				}
+			});
+		});
+
+		$.next();
+		$.append($$anchor, fragment_2);
+	});
+
+	$.append($$anchor, fragment);
+}

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/server/A.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/server/A.svelte.js
@@ -1,0 +1,7 @@
+import * as $ from 'svelte/internal/server';
+
+export default function A($$renderer, $$props) {
+	let { item } = $$props;
+
+	$$renderer.push(`<span>${$.escape(item)}</span>`);
+}

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/server/index.svelte.js
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/_expected/server/index.svelte.js
@@ -1,0 +1,45 @@
+import * as $ from 'svelte/internal/server';
+import A from './A.svelte';
+
+export default function Lone_dynamic_component($$renderer) {
+	let Component = A;
+	let items = [1, 2, 3];
+
+	$$renderer.push(`<!--[-->`);
+
+	const each_array = $.ensure_array_like(items);
+
+	for (let $$index = 0, $$length = each_array.length; $$index < $$length; $$index++) {
+		let item = each_array[$$index];
+
+		if (Component) {
+			$$renderer.push('<!--[-->');
+			Component($$renderer, { item });
+			$$renderer.push('<!--]-->');
+		} else {
+			$$renderer.push('<!--[!-->');
+			$$renderer.push('<!--]-->');
+		}
+	}
+
+	$$renderer.push(`<!--]--> <!--[-->`);
+
+	const each_array_1 = $.ensure_array_like(items);
+
+	for (let $$index_1 = 0, $$length = each_array_1.length; $$index_1 < $$length; $$index_1++) {
+		let item = each_array_1[$$index_1];
+
+		if (Component) {
+			$$renderer.push('<!--[-->');
+			Component($$renderer, { item });
+			$$renderer.push('<!--]-->');
+		} else {
+			$$renderer.push('<!--[!-->');
+			$$renderer.push('<!--]-->');
+		}
+
+		$$renderer.push(`<span></span>`);
+	}
+
+	$$renderer.push(`<!--]-->`);
+}

--- a/packages/svelte/tests/snapshot/samples/lone-dynamic-component/index.svelte
+++ b/packages/svelte/tests/snapshot/samples/lone-dynamic-component/index.svelte
@@ -1,0 +1,12 @@
+<script>
+	import A from './A.svelte';
+
+	let Component = $state(A);
+	let items = $state([1, 2, 3]);
+</script>
+
+<!-- sole child of the block, so no anchor comment is needed for it -->
+{#each items as item}<Component {item} />{/each}
+
+<!-- not the sole child, so it still gets one -->
+{#each items as item}<Component {item} /><span></span>{/each}


### PR DESCRIPTION
When a component is the only child of a block, `is_standalone` lets it render into the block's anchor rather than creating a comment anchor of its own. That optimisation was gated off for dynamic components. This removes the gate.

Namespaced components (`<Button.Primary />`, `<Combobox.Input />`) are always dynamic, so any app built on a component library in that style pays for an anchor at almost every call site. On a 2099 component SvelteKit app I measured:

| | before | after |
|---|---|---|
| `$.comment()` anchors | 4297 | 1364 |
| components emitting an anchor | 1256 | 932 |
| raw output | 12,093,207 | 11,708,984 |
| minified + brotli | 880,200 | 863,050 |

2933 of the app's 7909 `$.component` call sites qualify. They are spread across the codebase rather than concentrated in one pattern: 2717 sit in `{#if}` branches, snippets and component children, and 216 in `{#each}` bodies. Each one drops two DOM nodes per instance, a comment and a text node, plus the `$.comment()` / `$.first_child()` / `$.append()` calls around them.

Codegen, with and without a sibling:

```js
// sole child, no anchor
$.each(node, 17, () => items, $.index, ($$anchor, item) => {
	$.component($$anchor, () => Component, ...);
});

// has a sibling, anchor retained
$.each(node_1, 17, () => items, $.index, ($$anchor, item) => {
	var fragment_2 = root();
	var node_2 = $.first_child(fragment_2);
	$.component(node_2, () => Component, ...);
	$.next();
	$.append($$anchor, fragment_2);
});
```

This applies to `<svelte:component>` and `$state`-valued components too, not just namespaced ones.

## Runtime changes

Two things are needed for a dynamic block to live without its own anchor:

- `get_effect_nodes` derives an effect's DOM boundary from its children. An effect whose only content is a block owns no `nodes` itself, so `move()` in `each.js` previously bailed out and a keyed reorder moved nothing.
- `$.component` claims that boundary and steps over the closing hydration marker when there is no anchor. The `$.comment()` / `$.append()` pair used to do both.

`get_effect_nodes` only walks children when an effect has no `nodes` of its own, and returns the child's object directly in the single child case, so there is no allocation on the common path.

## Notes

- Hydration is unchanged. The server still emits the block markers, so those nodes are still in the delivered HTML.
- Per instance cost, mounting 1000 components in a keyed each in headless chromium: 3.30ms to 2.00ms, reorder 8.30ms to 6.30ms, 5003 DOM nodes to 3003.
- Extending `is_standalone` to `{#if}`, `{#each}` and `{#key}` does not work yet: each block type needs its own version of the `$.component` hydration change. `get_effect_nodes` itself is generic and would be reused.
- Verified with the full suite in both async and `SVELTE_NO_ASYNC=true` modes, and with `tests/manual/each-stress-test` adapted so its each body is a single dynamic component, over 300 randomised keyed reconciliations with and without transitions.
