### PR TITLE
fix: preserve original location

### DIFF
--- a/packages/svelte/src/compiler/index.js
+++ b/packages/svelte/src/compiler/index.js
@@ -26,7 +26,7 @@ export function compile(source, options) {
 
 	const validated = validate_component_options(options, '');
 
-	let parsed = _parse(source);
+	let parsed = _parse(source, false, options.sourcemap);
 
 	const { customElement: customElementOptions, ...parsed_options } = parsed.options || {};
 

--- a/packages/svelte/src/compiler/phases/1-parse/index.js
+++ b/packages/svelte/src/compiler/phases/1-parse/index.js
@@ -327,10 +327,11 @@ export class Parser {
 /**
  * @param {string} template
  * @param {boolean} [loose]
+ * @param {object | string} [sourcemap]
  * @returns {AST.Root}
  */
-export function parse(template, loose = false) {
-	state.set_source(template);
+export function parse(template, loose = false, sourcemap) {
+	state.set_source(template, sourcemap);
 
 	const parser = new Parser(template, loose);
 	return parser.root;

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-template/index.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-template/index.js
@@ -15,7 +15,7 @@ function build_locations(nodes) {
 	for (const node of nodes) {
 		if (node.type !== 'element') continue;
 
-		const { line, column } = locator(node.start);
+		const { line, column } = locator(node.start, true);
 
 		const expression = b.array([b.literal(line), b.literal(column)]);
 		const children = build_locations(node.children);

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -1,6 +1,7 @@
 /** @import { Location } from 'locate-character' */
 /** @import { CompileOptions } from './types' */
 /** @import { AST, Warning } from '#compiler' */
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
 import { getLocator } from 'locate-character';
 import { sanitize_location } from '../utils.js';
 
@@ -46,20 +47,33 @@ export let dev;
 
 export let runes = false;
 
-/** @type {(index: number) => Location} */
+/** @type {(index: number, use_sourcemap?: boolean) => Location} */
 export let locator;
 
-/** @param {string} value */
-export function set_source(value) {
+/**
+ * @param {string} value
+ * @param {object | string} [sourcemap]
+ */
+export function set_source(value, sourcemap) {
 	source = value;
 	source_lines = source.split('\n');
 
+	const map = (sourcemap && typeof sourcemap === 'object')
+		? new TraceMap( /** @type {any} */ (sourcemap))
+		: null;
+
 	const l = getLocator(source, { offsetLine: 1 });
 
-	locator = (i) => {
+	locator = (i, use_sourcemap=false) => {
 		const loc = l(i);
 		if (!loc) throw new Error('An impossible situation occurred');
-
+		if (use_sourcemap && map) {
+			const original = originalPositionFor(map, loc);
+			if (original.line != null && original.column != null) {
+				loc.line = original.line;
+				loc.column = original.column;
+			}
+		}
 		return loc;
 	};
 }

--- a/packages/svelte/src/compiler/state.js
+++ b/packages/svelte/src/compiler/state.js
@@ -58,13 +58,14 @@ export function set_source(value, sourcemap) {
 	source = value;
 	source_lines = source.split('\n');
 
-	const map = (sourcemap && typeof sourcemap === 'object')
-		? new TraceMap( /** @type {any} */ (sourcemap))
-		: null;
+	const map =
+		sourcemap && typeof sourcemap === 'object'
+			? new TraceMap(/** @type {any} */ (sourcemap))
+			: null;
 
 	const l = getLocator(source, { offsetLine: 1 });
 
-	locator = (i, use_sourcemap=false) => {
+	locator = (i, use_sourcemap = false) => {
 		const loc = l(i);
 		if (!loc) throw new Error('An impossible situation occurred');
 		if (use_sourcemap && map) {


### PR DESCRIPTION
Fix #18704


The svelte compiler ignore the previous sourcemap when it generate the `$.add_locations()` in dev mode, which is used by the Svelte Inspector to retrieve the component on the code editor.

This makes it incompatible with tools that transform the source code before the Svelte compiler, such as Wuchale.

So I use `@jridgewell/trace-mapping` in order to fix the locations of `$.add_locations()`.

Note that I'm not sur of this PR :
* There is a potential impact on performance, due to the sourcemap parsing.
* I have a type issue on `new TraceMap()` so I used a cast to `any` :(
* I don't known how to create a test for that.


### Before submitting the PR, please make sure you do the following

- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
- [ ] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`
