### PR TITLE
fix: properly apply static textarea value attribute during CSR

### DIFF
--- a/.changeset/polite-zoos-melt.md
+++ b/.changeset/polite-zoos-melt.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: properly apply static textarea value attribute during CSR

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js
@@ -240,6 +240,7 @@ export function RegularElement(node, context) {
 			if (
 				!is_custom_element &&
 				!cannot_be_set_statically(attribute.name) &&
+				(name !== 'value' || node.name !== 'textarea') &&
 				(attribute.value === true || is_text_attribute(attribute)) &&
 				(name !== 'class' || class_directives.length === 0) &&
 				(name !== 'style' || style_directives.length === 0)

--- a/packages/svelte/tests/runtime-legacy/samples/textarea-value/_config.js
+++ b/packages/svelte/tests/runtime-legacy/samples/textarea-value/_config.js
@@ -5,14 +5,19 @@ export default test({
 		return { foo: 42 };
 	},
 
-	html: '<textarea></textarea>',
-	ssrHtml: '<textarea>42</textarea>',
+	ssrHtml: '<textarea>42</textarea> <textarea>static</textarea>',
 
-	test({ assert, component, target }) {
-		const textarea = /** @type {HTMLTextAreaElement} */ (target.querySelector('textarea'));
-		assert.strictEqual(textarea.value, '42');
+	test({ assert, component, target, variant }) {
+		assert.htmlEqual(
+			target.innerHTML,
+			`<textarea></textarea> <textarea>${variant === 'hydrate' ? 'static' : ''}</textarea>`
+		);
+
+		const [textarea1, textarea2] = target.querySelectorAll('textarea');
+		assert.strictEqual(textarea1.value, '42');
+		assert.strictEqual(textarea2.value, 'static');
 
 		component.foo = 43;
-		assert.strictEqual(textarea.value, '43');
+		assert.strictEqual(textarea1.value, '43');
 	}
 });

--- a/packages/svelte/tests/runtime-legacy/samples/textarea-value/main.svelte
+++ b/packages/svelte/tests/runtime-legacy/samples/textarea-value/main.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <textarea value='{foo}'/>
+<textarea value="static"></textarea>


### PR DESCRIPTION
Fixes #18574
Simpler alternative to #18627 - we just special-case this in the "should this be treated as a dynamic attribute" branches so `$.set_value(...)` is always generated. Given how edge-case-y this is (why would you not just write it into the body of the textarea?) this is fine.
