### PR TITLE
fix: throw when `setContext` is called after an `await` during SSR

### DIFF
--- a/.changeset/olive-mice-argue.md
+++ b/.changeset/olive-mice-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: throw `set_context_after_init` when `setContext` is called after an `await` during SSR

--- a/documentation/docs/98-reference/.generated/client-errors.md
+++ b/documentation/docs/98-reference/.generated/client-errors.md
@@ -225,14 +225,6 @@ Rest element properties of `$props()` such as `%property%` are readonly
 The `%rune%` rune is only available inside `.svelte` and `.svelte.js/ts` files
 ```
 
-### set_context_after_init
-
-```
-`setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
-```
-
-This restriction only applies when using the `experimental.async` option, which will be active by default in Svelte 6.
-
 ### state_descriptors_fixed
 
 ```

--- a/documentation/docs/98-reference/.generated/shared-errors.md
+++ b/documentation/docs/98-reference/.generated/shared-errors.md
@@ -80,6 +80,14 @@ Context was not set in the current component or any of its ancestors
 
 The [`createContext()`](svelte#createContext) utility returns a `[get, set, has]` triplet of functions. `get` will throw an error if `set` was not used to set the context in the current component or any of its ancestors.
 
+### set_context_after_init
+
+```
+`setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
+```
+
+This restriction only applies when using the `experimental.async` option, which will be active by default in Svelte 6.
+
 ### snippet_without_render_tag
 
 ```

--- a/packages/svelte/messages/client-errors/errors.md
+++ b/packages/svelte/messages/client-errors/errors.md
@@ -171,12 +171,6 @@ This can happen if you render a hydratable on the client that was not rendered o
 
 > The `%rune%` rune is only available inside `.svelte` and `.svelte.js/ts` files
 
-## set_context_after_init
-
-> `setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
-
-This restriction only applies when using the `experimental.async` option, which will be active by default in Svelte 6.
-
 ## state_descriptors_fixed
 
 > Property descriptors defined on `$state` objects must contain `value` and always be `enumerable`, `configurable` and `writable`.

--- a/packages/svelte/messages/shared-errors/errors.md
+++ b/packages/svelte/messages/shared-errors/errors.md
@@ -66,6 +66,12 @@ Certain lifecycle methods can only be used during component initialisation. To f
 
 The [`createContext()`](svelte#createContext) utility returns a `[get, set, has]` triplet of functions. `get` will throw an error if `set` was not used to set the context in the current component or any of its ancestors.
 
+## set_context_after_init
+
+> `setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
+
+This restriction only applies when using the `experimental.async` option, which will be active by default in Svelte 6.
+
 ## snippet_without_render_tag
 
 > Attempted to render a snippet without a `{@render}` block. This would cause the snippet code to be stringified instead of its content being rendered to the DOM. To fix this, change `{snippet}` to `{@render snippet()}`.

--- a/packages/svelte/src/internal/client/errors.js
+++ b/packages/svelte/src/internal/client/errors.js
@@ -430,22 +430,6 @@ export function rune_outside_svelte(rune) {
 }
 
 /**
- * `setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
- * @returns {never}
- */
-export function set_context_after_init() {
-	if (DEV) {
-		const error = new Error(`set_context_after_init\n\`setContext\` must be called when a component first initializes, not in a subsequent effect or after an \`await\` expression\nhttps://svelte.dev/e/set_context_after_init`);
-
-		error.name = 'Svelte error';
-
-		throw error;
-	} else {
-		throw new Error(`https://svelte.dev/e/set_context_after_init`);
-	}
-}
-
-/**
  * Property descriptors defined on `$state` objects must contain `value` and always be `enumerable`, `configurable` and `writable`.
  * @returns {never}
  */

--- a/packages/svelte/src/internal/server/context.js
+++ b/packages/svelte/src/internal/server/context.js
@@ -1,6 +1,7 @@
 /** @import { SSRContext } from '#server' */
 import { DEV } from 'esm-env';
 import { create_context, get_or_init_context_map } from '../shared/context.js';
+import * as e from './errors.js';
 
 /** @type {SSRContext | null} */
 export var ssr_context = null;
@@ -40,7 +41,13 @@ export function getContext(key) {
  * @returns {T}
  */
 export function setContext(key, context) {
-	get_or_init_context_map(ssr_context, 'setContext').set(key, context);
+	const context_map = get_or_init_context_map(ssr_context, 'setContext');
+
+	if (/** @type {SSRContext} */ (ssr_context).i) {
+		e.set_context_after_init();
+	}
+
+	context_map.set(key, context);
 	return context;
 }
 
@@ -61,7 +68,7 @@ export function getAllContexts() {
  * @param {Function} [fn]
  */
 export function push(fn) {
-	ssr_context = { p: ssr_context, c: null, r: null };
+	ssr_context = { p: ssr_context, c: null, r: null, i: false };
 
 	if (DEV) {
 		ssr_context.function = fn;

--- a/packages/svelte/src/internal/server/renderer.js
+++ b/packages/svelte/src/internal/server/renderer.js
@@ -162,6 +162,11 @@ export class Renderer {
 		let promise = Promise.resolve(thunks[0]());
 		const promises = [promise];
 
+		if (context !== null && thunks.length > 1) {
+			// the remaining thunks run after an `await`, by which point it is too late to set context
+			context.i = true;
+		}
+
 		for (const fn of thunks.slice(1)) {
 			promise = promise.then(() => {
 				const previous_context = ssr_context;
@@ -209,7 +214,8 @@ export class Renderer {
 			...ssr_context,
 			p: parent,
 			c: null,
-			r: child
+			r: child,
+			i: ssr_context?.i ?? false
 		});
 
 		const result = fn(child);
@@ -260,7 +266,8 @@ export class Renderer {
 			...ssr_context,
 			p: parent_context,
 			c: null,
-			r: child
+			r: child,
+			i: ssr_context?.i ?? false
 		});
 
 		try {
@@ -859,7 +866,7 @@ export class Renderer {
 
 		try {
 			/** @type {SSRContext} */
-			const context = { p: null, c: options.context ?? null, r: renderer };
+			const context = { p: null, c: options.context ?? null, r: renderer, i: false };
 			set_ssr_context(context);
 
 			renderer.push(BLOCK_OPEN);

--- a/packages/svelte/src/internal/server/types.d.ts
+++ b/packages/svelte/src/internal/server/types.d.ts
@@ -9,6 +9,8 @@ export interface SSRContext {
 	c: null | Map<unknown, unknown>;
 	/** renderer */
 	r: null | Renderer;
+	/** True if initialized, i.e. an `await` was reached */
+	i: boolean;
 	/** dev mode only: the current component function */
 	function?: any;
 	/** dev mode only: the current element */

--- a/packages/svelte/src/internal/shared/errors.js
+++ b/packages/svelte/src/internal/shared/errors.js
@@ -102,6 +102,22 @@ export function missing_context() {
 }
 
 /**
+ * `setContext` must be called when a component first initializes, not in a subsequent effect or after an `await` expression
+ * @returns {never}
+ */
+export function set_context_after_init() {
+	if (DEV) {
+		const error = new Error(`set_context_after_init\n\`setContext\` must be called when a component first initializes, not in a subsequent effect or after an \`await\` expression\nhttps://svelte.dev/e/set_context_after_init`);
+
+		error.name = 'Svelte error';
+
+		throw error;
+	} else {
+		throw new Error(`https://svelte.dev/e/set_context_after_init`);
+	}
+}
+
+/**
  * Attempted to render a snippet without a `{@render}` block. This would cause the snippet code to be stringified instead of its content being rendered to the DOM. To fix this, change `{snippet}` to `{@render snippet()}`.
  * @returns {never}
  */

--- a/packages/svelte/tests/server-side-rendering/samples/async-context-throws-after-await/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/async-context-throws-after-await/_config.js
@@ -1,7 +1,6 @@
 import { test } from '../../test';
 
 export default test({
-	skip: true, // TODO it appears there might be an actual bug here; the promise isn't ever actually awaited in spite of being awaited in the component
 	mode: ['async'],
-	error: 'lifecycle_outside_component'
+	error: 'set_context_after_init'
 });


### PR DESCRIPTION
Fixes #17233.

`setContext` after a top-level `await` throws `set_context_after_init` on the client since #17031, but the server never got the equivalent check, so it silently succeeded.

### Why `pop()` is the wrong place

The client marks `component_context.i = true` in `pop()`. Doing the same on the server does not work, and it fails silently, so it is worth spelling out.

`Renderer.component` calls `push()`, then `child()`, then `pop()`. But `child()` does not reuse the pushed context, it rebuilds it:

```js
set_ssr_context({ ...ssr_context, p: parent, c: null, r: child });
```

The component body runs inside that spread copy, so `Renderer.run` captures the copy, not the object `push()` created. `pop()` then mutates the original, which nothing reads again. I tried it: with the flag set in `pop()` and the test un-skipped, the guard never fires and the test still fails with `Expected an error to be thrown, but rendering succeeded.`

### What this does instead

The compiler already draws the line for us. `<script>` code around a top-level `await` compiles to:

```js
$$renderer.run([
	() => Promise.resolve('hi'),
	() => void setContext('key', 'value')
]);
```

`thunks[0]` is the awaited expression and everything before it stays outside `run()` entirely. Every thunk from index 1 on is resumed from a `.then()`, so it is by definition post-await. So `run()` marks its captured context once, when there is more than one thunk, and `setContext` checks the flag.

The check does not need an `async_mode_flag` guard the way the client's does. `run()` is only ever emitted under `experimental.async`, so the flag cannot be set in sync mode.

`push()` and the root context in `#open_render` now set `i: false`, and `set_context_after_init` moves from client to shared errors so both runtimes throw the same code, the same way `lifecycle_outside_component` already does. The error text and its `svelte.dev/e/` page are unchanged.

### The skipped test

The sample from #17154 is un-skipped. Its comment said:

> TODO it appears there might be an actual bug here; the promise isn't ever actually awaited in spite of being awaited in the component

That is not what is happening, so I removed it rather than reword it. Rendering that component with a 120ms timer instead of `Promise.resolve` shows the render waiting for it and collecting output written after the await:

```
t+0ms    thunk0: starting 120ms timer
t+122ms  timer fired
t+122ms  thunk1: post-await, calling setContext
t+122ms  thunk1: setContext returned normally
t+122ms  awaited render, body = "<!--[-->POST_AWAIT_CONTENT<!--]-->"
```

The promise is awaited. The only thing missing was the guard. The expected error also changes from `lifecycle_outside_component` to `set_context_after_init`, matching the client.

### Not changed

`setContext('key', await x)` compiles to a single thunk, so it is outside what this checks. On `main` it already fails with `lifecycle_outside_component`, and it still does. Worth a separate look, but it is a different shape from the one in the issue.

### Test plan

`pnpm test`, before and after, on the same machine:

| | files | passed | skipped |
|---|---|---|---|
| `main` | 34 | 7762 | 56 |
| this branch | 34 | 7763 | 55 |

The only delta is the sample that was skipped.

Counterfactual, with the test un-skipped and only the `run()` marking removed:

```
FAIL  packages/svelte/tests/server-side-rendering/test.ts > async-context-throws-after-await (async)
AssertionError: Expected an error to be thrown, but rendering succeeded.
```

Restored, it passes.

Negative cases, checked directly against the compiled SSR shapes so the guard is not just eager:

| case | result |
|---|---|
| `setContext` after `await` | throws `set_context_after_init` |
| `setContext` before `await` | works |
| `setContext`, no `await` | works |
| `setContext` before and after `await` | throws on the second |
| two `await`s then `setContext` | throws |
| parent awaits, child sets context | works |

The last one matters: a child goes through `push()`, which builds a fresh context, so the parent's flag does not leak into it. The existing `server-side-rendering/samples/context` and `runtime-runes/samples/async-set-context` samples both cover that shape and both still pass.

`pnpm lint` and `pnpm check` are clean.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`
