### PR TITLE
docs: document CSS custom property spread limitation and workaround

### DIFF
--- a/documentation/docs/04-styling/03-custom-properties.md
+++ b/documentation/docs/04-styling/03-custom-properties.md
@@ -56,3 +56,32 @@ Inside the component, we can read these custom properties (and provide fallback 
 You don't _have_ to specify the values directly on the component; as long as the custom properties are defined on a parent element, the component can use them. It's common to define custom properties on the `:root` element in a global stylesheet so that they apply to your entire application.
 
 > [!NOTE] While the extra element will not affect layout, it _will_ affect any CSS selectors that (for example) use the `>` combinator to target an element directly inside the component's container.
+
+## Limitations
+
+CSS custom properties must be passed as explicit named attributes — they cannot be included in a spread object. Svelte uses static analysis at compile time to identify `--`-prefixed attributes; spread objects are opaque to this analysis.
+
+```svelte
+<script>
+	let theme = { '--track-color': 'black', '--thumb-color': 'blue' };
+</script>
+
+<!-- ❌ does not work — custom properties inside spreads are not detected -->
+<Slider {...theme} />
+
+<!-- ✅ pass each custom property explicitly -->
+<Slider --track-color="black" --thumb-color="blue" />
+```
+
+If you need to forward a dynamic set of custom properties (for example, from a theme object whose keys are not known at compile time), apply them as a `style` string on a wrapper element instead:
+
+```svelte
+<script>
+	let theme = { '--track-color': 'black', '--thumb-color': 'blue' };
+	let themeStyle = Object.entries(theme).map(([k, v]) => `${k}: ${v}`).join('; ');
+</script>
+
+<div style={themeStyle}>
+	<Slider bind:value min={0} max={100} />
+</div>
+```


### PR DESCRIPTION
Closes #15943

## Summary

CSS custom properties must be passed to components as explicit named attributes (e.g. `--track-color="black"`). They **cannot** be included in a spread object — Svelte detects `--`-prefixed attributes via static analysis at compile time, which cannot inspect the contents of a spread.

This PR adds a **Limitations** section to the CSS custom properties page that:
- States the constraint clearly with a ❌/✅ code example
- Provides the `style`-string-on-wrapper workaround for cases where the set of custom properties is dynamic or unknown at compile time

## Test plan

Documentation-only change; no code was modified.

- Verified that the existing docs don't already cover this case
- Confirmed the workaround (wrapper `<div style={themeStyle}>`) is correct per the maintainer's comment in #15943 ("to work we need to wrap the component in an element with display contents and the css variables as inline styles")