### PR TITLE
docs: fix await_waterfall workaround — use eager const, not lazy $derived

### DIFF
--- a/packages/svelte/messages/client-warnings/warnings.md
+++ b/packages/svelte/messages/client-warnings/warnings.md
@@ -93,18 +93,20 @@ let b = $derived(await two());
 
 (Note that if the values of `await one()` and `await two()` subsequently change, they can do so concurrently — the waterfall only occurs when the deriveds are first created.)
 
-You can solve this by creating the promises first and _then_ awaiting them:
+You can solve this by starting the promises _before_ awaiting them. Because `$derived` is lazy — the expression only runs when the value is first read — using `$derived(one())` does not help: `one()` still isn't called until `aPromise` is read for the first time, which happens on the `$derived(await aPromise)` line. Use plain `const` or `let` declarations so both functions are called eagerly, before either await runs:
 
 ```js
 async function one() { return 1 }
 async function two() { return 2 }
 // ---cut---
-let aPromise = $derived(one());
-let bPromise = $derived(two());
+const aPromise = one();
+const bPromise = two();
 
 let a = $derived(await aPromise);
 let b = $derived(await bPromise);
 ```
+
+> [!NOTE] This approach only eliminates the waterfall when `one()` and `two()` do not themselves depend on reactive state. If the promise-creating expressions read `$state` or `$derived` values, there is currently no way to avoid the waterfall.
 
 ## binding_property_non_reactive
 


### PR DESCRIPTION
Closes #16483

## Summary

The `await_waterfall` warning documentation claimed you can eliminate a waterfall by writing:

```js
let aPromise = $derived(one());
let bPromise = $derived(two());

let a = $derived(await aPromise);
let b = $derived(await bPromise);
```

This **does not work**. `$derived` is lazy — `one()` is not called when `let aPromise = $derived(one())` is declared. It is called when `aPromise` is first read, which happens inside `$derived(await aPromise)`. Both calls therefore still happen sequentially, preserving the waterfall.

## Fix

Replace `$derived(one())` with `const aPromise = one()` so both functions are called eagerly before any `await` executes:

```js
const aPromise = one();
const bPromise = two();

let a = $derived(await aPromise);
let b = $derived(await bPromise);
```

Also adds a `[!NOTE]` clarifying that this approach only helps when `one()` and `two()` do not read reactive state. When they do, the waterfall is currently unavoidable.

## Test plan

Documentation-only change. No runtime code was modified.