### PR TITLE
fix: preserve teardown values across follow-up batches

### DIFF
--- a/.changeset/calm-spiders-breathe.md
+++ b/.changeset/calm-spiders-breathe.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: prevent attachment state cleanup loops across follow-up batches

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -420,7 +420,6 @@ export class Batch {
 		}
 
 		if (next_batch !== null) {
-			old_values.clear();
 			next_batch.#process();
 		}
 	}

--- a/packages/svelte/tests/runtime-runes/samples/attachment-state-cleanup-loop/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-state-cleanup-loop/_config.js
@@ -1,0 +1,15 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		flushSync(() => button?.click());
+
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>show</button> <div data-attached="true">content</div>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/attachment-state-cleanup-loop/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-state-cleanup-loop/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let visible = $state(false);
+	let element = $state();
+
+	function attachment(node) {
+		element = node;
+		element.dataset.attached = 'true';
+
+		return () => {
+			if (element === node) {
+				element = undefined;
+			}
+		};
+	}
+</script>
+
+<button onclick={() => (visible = true)}>show</button>
+
+{#if visible}
+	<div {@attach attachment}>content</div>
+{/if}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

---

Fixes #18744.

### Problem

#18620 made `old_values` keep the value from before the first write in a flush. It also clears that map before processing a follow-up batch.

An attachment that stores its node in state, reads that state during setup, and clears it during cleanup then repeats forever:

1. setup stores and reads the node, which schedules the attachment again;
2. the intermediate clear removes the old-value snapshot;
3. cleanup sees the current node and clears it;
4. setup stores it again, scheduling another follow-up batch.

This throws `effect_update_depth_exceeded`. It is a regression from 5.56.8 and first appears in 5.56.10.

### Fix

Keep `old_values` through follow-up batches in the same outer flush. `Batch.flush()` already clears the map in its `finally` block after all follow-up work ends.

This keeps the first-write snapshot promised by #18620 while preventing attachment setup and cleanup from alternating the same state forever.

The new runtime-runes sample fails in both DOM and hydration modes before this change and passes after it.

### Test plan

- `pnpm test`
  - 34 test files passed
  - 7,764 tests passed, 56 skipped
- `SVELTE_NO_ASYNC=true pnpm test runtime-runes`
  - 1,815 tests passed, 9 skipped
- `pnpm lint`
- `pnpm --filter svelte check`
- `pnpm build`
- Shyori focused Playwright flow with the patched Svelte 5.57.0 package
  - passkey signup, UnitSwitcher open/select, logout, and conditional login passed
