### PR TITLE
fix: bump printer dependency floor to 2.3.5

### DIFF
--- a/.changeset/raise-printer-floor.md
+++ b/.changeset/raise-printer-floor.md
@@ -1,0 +1,5 @@
+---
+"svelte": patch
+---
+
+Fixed [#18643](https://github.com/sveltejs/svelte/issues/18643): raised the printer dependency floor so a broken 2.3.3 release cannot be resolved. Server codegen for `@type` JSDoc on `export let` plus `$:` is valid JS again.

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -181,7 +181,7 @@
     "clsx": "^2.1.1",
     "devalue": "^5.8.1",
     "esm-env": "^1.2.1",
-    "esrap": "^2.2.12",
+    "esrap": "^2.3.5",
     "is-reference": "^3.0.3",
     "locate-character": "^3.0.0",
     "magic-string": "^0.30.11",

--- a/packages/svelte/tests/jsdoc-type-reactive-server.test.ts
+++ b/packages/svelte/tests/jsdoc-type-reactive-server.test.ts
@@ -1,0 +1,24 @@
+import { parse } from 'acorn';
+import { assert, describe, it } from 'vitest';
+import { compile } from 'svelte/compiler';
+
+const source = `<script>
+	/** @type {string} */
+	export let a = 'x';
+	$: c = a;
+</script>
+
+{c}
+`;
+
+describe('server codegen with @type JSDoc and reactive declaration', () => {
+	it('emits parseable JavaScript', () => {
+		const { js } = compile(source, {
+			generate: 'server',
+			filename: 'MinRepro.svelte'
+		});
+
+		assert.ok(!/let \/\*\* @type \{string\} \*\/ \(/.test(js.code), js.code);
+		parse(js.code, { ecmaVersion: 'latest', sourceType: 'module' });
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       esrap:
-        specifier: ^2.2.12
-        version: 2.2.12(@typescript-eslint/types@8.59.4)
+        specifier: ^2.3.5
+        version: 2.3.6(@typescript-eslint/types@8.59.4)
       is-reference:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1569,8 +1569,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.12:
-    resolution: {integrity: sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==}
+  esrap@2.3.6:
+    resolution: {integrity: sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -3920,7 +3920,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.12(@typescript-eslint/types@8.59.4):
+  esrap@2.3.6(@typescript-eslint/types@8.59.4):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with feat:, fix:, chore:, or docs:.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within packages/svelte/src, add a changeset (npx changeset).

### Tests and linting

- [x] Ran the new regression test. did not re-run full-repo lint, this is a dependency range only.

fixes #18643

Older esrap emitted invalid server JS for JSDoc-annotated declarations. we bump the printer floor to 2.3.5.

We added a regression test and a patch changeset.