### PR TITLE
fix: don't bail scheduling on a branch owned by a dropped batch

### DIFF
--- a/.changeset/silly-donkeys-repair.md
+++ b/.changeset/silly-donkeys-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't bail scheduling on a branch owned by a dropped batch

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -966,16 +966,26 @@ export class Batch {
 			}
 
 			if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
-				if ((flags & CLEAN) === 0) {
-					// branch is already dirty, bail
-					return;
+				// Mark the branch dirty if it isn't already. Previously we bailed here
+				// when the branch was already dirty, assuming some batch already had
+				// the root queued for traversal. But CLEAN/DIRTY flags live on the
+				// shared effect tree while `#roots` is per-batch, so that assumption
+				// breaks when the owning batch is dropped (e.g. after a `flushSync()`
+				// inside a render-phase effect drops a batch whose roots were already
+				// populated), leaving the root marked dirty but owned by no batch.
+				// Every later schedule() would then bail here and traverse nothing,
+				// permanently killing the root's reactivity. Instead, keep walking to
+				// the root and enqueue it (deduped) so this batch traverses it.
+				// See https://github.com/sveltejs/svelte/issues/18546
+				if ((flags & CLEAN) !== 0) {
+					e.f ^= CLEAN;
 				}
-
-				e.f ^= CLEAN;
 			}
 		}
 
-		this.#roots.push(e);
+		if (!this.#roots.includes(e)) {
+			this.#roots.push(e);
+		}
 	}
 
 	#unlink() {

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-render-effect-drops-batch/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-render-effect-drops-batch/_config.js
@@ -1,0 +1,41 @@
+import { test } from '../../test';
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// Regression test for https://github.com/sveltejs/svelte/issues/18546
+// A render-phase effect ($effect.pre) that calls flushSync() causes a batch to
+// be dropped after its roots were populated, leaving ancestor effects marked
+// not-CLEAN but owned by no batch. Every subsequent schedule() then hits the
+// "branch is already dirty, bail" path and traverses nothing, permanently
+// killing the reactivity of the whole root. Only reproduces with `dev: false`.
+//
+// NOTE: step2 must rely on the natural (microtask) flush — wrapping it in
+// flushSync() rescues the orphaned batch and masks the bug.
+export default test({
+	mode: ['client'],
+
+	compileOptions: {
+		dev: false
+	},
+
+	async test({ assert, target }) {
+		const [step1, step2] = target.querySelectorAll('button');
+
+		// step1: enter "restoring" (render-phase flushSync) + switch item to B.
+		// step1's own handler calls flushSync(), so this settles synchronously.
+		step1?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>step1</button><button>step2</button><p>shown=B</p>'
+		);
+
+		// step2: switch item to C, relying on the natural async flush.
+		step2?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>step1</button><button>step2</button><p>shown=C</p>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-render-effect-drops-batch/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-render-effect-drops-batch/main.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	let s = $state({ restoring: false, item: 'A', shown: '-' });
+
+	$effect.pre(() => {
+		if (s.restoring) flushSync();
+	});
+
+	$effect.pre(() => {
+		s.shown = s.item;
+	});
+</script>
+
+<button onclick={() => { s.restoring = true; s.item = 'B'; flushSync(); }}>step1</button>
+<button onclick={() => { s.item = 'C'; }}>step2</button>
+<p>shown={s.shown}</p>


### PR DESCRIPTION
### Problem

A `flushSync()` inside a render-phase effect (`$effect.pre`) can permanently kill the reactivity of an entire root — no error is thrown, the DOM just silently stops updating until a reload. Fixes #18546.

`Batch.prototype.schedule()` walks up the effect tree and, on reaching a `ROOT_EFFECT`/`BRANCH_EFFECT` that is already dirty (not `CLEAN`), bails early — assuming some batch already has that root queued for traversal. But as @Deeds67 diagnosed, `CLEAN`/`DIRTY` flags live on the *shared* effect tree while `#roots` is *per-batch*. When a render-phase `flushSync()` re-enters `flush()`, its `finally` nulls `current_batch`; a later pre-effect's write then makes `Batch.ensure()` create a fresh batch (with no rescue microtask, since `is_flushing_sync` is true), whose roots are populated and then dropped when the outer `#process()` sets `current_batch = null`. The ancestors are left marked dirty but owned by no batch, so every later `schedule()` hits the bail path and traverses nothing.

### Fix

In `schedule()` (`reactivity/batch.js`), stop treating an already-dirty ancestor as proof that some batch owns the root: keep walking to the root and enqueue it in `#roots` (deduped) so the current batch always traverses it.

### Test

`tests/runtime-runes/samples/flush-sync-render-effect-drops-batch`. It reproduces the permanent-staleness (asserts `shown` reaches `C` after step 2) and fails without this change.

Scope note: this only manifests in **non-async** mode — the async scheduler defers render effects rather than running them during traversal, so the re-entrancy window doesn't open. The test therefore bites under CI's `SVELTE_NO_ASYNC=true runtime-runes` job (and stays green in the default async run); the svelte.dev Playground masks it for the same reason. @Deeds67 also notes a possibly more surgical fix in `#process()`/`ensure()` (stop dropping the batch) — I went with the `schedule()` guard as the smallest clearly-correct change, but defer the approach to maintainers.

---
Analysis and patch prepared with AI assistance.
