### PR TITLE
fix: report invalid placement for all elements that auto-close a `<p>`

### DIFF
--- a/.changeset/violet-berries-repair.md
+++ b/.changeset/violet-berries-repair.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: report invalid placement for all elements that auto-close a `<p>`

--- a/packages/svelte/src/html-tree-validation.js
+++ b/packages/svelte/src/html-tree-validation.js
@@ -10,15 +10,22 @@ const autoclosing_children = {
 	// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt#technical_summary
 	dt: { descendant: ['dt', 'dd'], reset_by: ['dl'] },
 	dd: { descendant: ['dt', 'dd'], reset_by: ['dl'] },
+	// https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody
 	p: {
 		descendant: [
 			'address',
 			'article',
 			'aside',
 			'blockquote',
+			'center',
+			'details',
+			'dialog',
+			'dir',
 			'div',
 			'dl',
 			'fieldset',
+			'figcaption',
+			'figure',
 			'footer',
 			'form',
 			'h1',
@@ -36,7 +43,9 @@ const autoclosing_children = {
 			'ol',
 			'p',
 			'pre',
+			'search',
 			'section',
+			'summary',
 			'table',
 			'ul'
 		]

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-9/input.svelte
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-9/input.svelte
@@ -1,0 +1,13 @@
+<p>
+	{#if foo}
+		<center>a</center>
+		<details>b</details>
+		<dialog>c</dialog>
+		<dir>d</dir>
+		<figure>e</figure>
+		<search>f</search>
+		<summary>g</summary>
+		<!-- svelte-ignore a11y_figcaption_parent -->
+		<figcaption>h</figcaption>
+	{/if}
+</p>

--- a/packages/svelte/tests/validator/samples/invalid-node-placement-9/warnings.json
+++ b/packages/svelte/tests/validator/samples/invalid-node-placement-9/warnings.json
@@ -1,0 +1,98 @@
+[
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<center>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 3,
+			"column": 2
+		},
+		"end": {
+			"line": 3,
+			"column": 20
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<details>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 4,
+			"column": 2
+		},
+		"end": {
+			"line": 4,
+			"column": 22
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<dialog>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 5,
+			"column": 2
+		},
+		"end": {
+			"line": 5,
+			"column": 20
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<dir>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 6,
+			"column": 2
+		},
+		"end": {
+			"line": 6,
+			"column": 14
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<figure>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 7,
+			"column": 2
+		},
+		"end": {
+			"line": 7,
+			"column": 20
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<search>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 8,
+			"column": 2
+		},
+		"end": {
+			"line": 8,
+			"column": 20
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<summary>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 9,
+			"column": 2
+		},
+		"end": {
+			"line": 9,
+			"column": 22
+		}
+	},
+	{
+		"code": "node_invalid_placement_ssr",
+		"message": "`<figcaption>` cannot be a child of `<p>`. When rendering this component on the server, the resulting HTML will be modified by the browser (by moving, removing, or inserting elements), likely resulting in a `hydration_mismatch` warning",
+		"start": {
+			"line": 11,
+			"column": 2
+		},
+		"end": {
+			"line": 11,
+			"column": 28
+		}
+	}
+]


### PR DESCRIPTION
### Problem

`autoclosing_children.p` in `packages/svelte/src/html-tree-validation.js` lists the elements whose start tag implicitly closes an open `<p>`. Eight elements that the HTML parsing spec puts in that set are missing, so the compiler neither auto-closes the `<p>` nor reports `node_invalid_placement`, and SSR emits markup the browser then repairs.

From the "in body" insertion mode (https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody):

> A start tag whose tag name is one of: "address", "article", "aside", "blockquote", "center", "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure", "footer", "header", "hgroup", "main", "menu", "nav", "ol", "p", "search", "section", "summary", "ul"
>
> If the stack of open elements has a `p` element in button scope, then close a `p` element.
>
> Insert an HTML element for the token.

`center`, `details`, `dialog`, `dir`, `figcaption`, `figure`, `search` and `summary` are in the spec's list but not in Svelte's. `parse5` (the reference parser) routes all eight through `addressStartTagInBody`, which is the "close a p element" branch.

### Evidence

`<p>a<details>b</details>c</p>` compiled with `generate: 'ssr'` on `main` emits:

```
$$renderer.push(`<p>a<details>b</details>c</p>`);
```

The browser parses that string as `<p>a</p><details>b</details>c<p></p>`, so hydration sees a different tree than the server produced. The same template with `<div>` in place of `<details>` is already handled: the parser auto-closes the `<p>` and emits `<p>a</p><div>b</div>c`.

Nesting under an intermediate element makes the gap visible as a missing diagnostic. On `main`, `<p><span><div>foo</div></span></p>` is a `node_invalid_placement` error, while `<p><span><details>foo</details></span></p>` compiles without a warning, even though both are repaired identically by the browser.

### Fix

Add the eight missing tags to the `p` entry.

After the change, the same `<p>a<details>b</details>c</p>` template compiles the way the `<div>` version already did, and SSR emits `<p>a</p><details>b</details>c`, which matches the browser's parse.

### Test plan

New sample `packages/svelte/tests/validator/samples/invalid-node-placement-9` puts each of the eight tags inside an `{#if}` block in a `<p>`, so each one is expected to produce a `node_invalid_placement_ssr` warning. On unmodified `main` the compiler reports zero warnings for that sample; with the fix it reports all eight.

- `pnpm test validator` passes
- `pnpm test` passes: 34 files, 7770 tests, 0 failures (same counts as on `main`)
- `pnpm lint` clean for the touched files
