### PR TITLE
fix: flushSync at top of component script crashes and breaks reactivity (#18522)

### DIFF
--- a/.changeset/lucky-buttons-flush.md
+++ b/.changeset/lucky-buttons-flush.md
@@ -1,0 +1,9 @@
+---
+'svelte': patch
+---
+
+fix: `flushSync` at the top of a component script no longer crashes or breaks reactivity
+
+Calling `flushSync()` while the effect tree is still being constructed (e.g. at the top of a component's `<script>`) used to flush the in-flight batch mid-construction. The boundary then resolved against a nulled `current_batch` and crashed with `Cannot read properties of null (reading 'transfer_effects')`, and the half-built tree left the enclosing branch's CLEAN flag unbalanced — which made every later `schedule` call bail, silently killing reactivity.
+
+`flushSync` now detects that a branch/root effect's update is in flight and skips the flush (there is nothing user-visible to flush yet; the batch flushes normally once construction settles). The boundary's resolution also tolerates a null batch as defense in depth, transferring deferred effects into a fresh batch instead of crashing.

--- a/packages/svelte/src/internal/client/dom/blocks/boundary.js
+++ b/packages/svelte/src/internal/client/dom/blocks/boundary.js
@@ -333,6 +333,11 @@ export class Boundary {
 	#resolve(batch) {
 		this.is_pending = false;
 
+		// If no batch is active (e.g. `flushSync` was called during mount and
+		// flushed the batch the boundary is still inside), create one so the
+		// deferred effects still get flushed instead of being dropped.
+		if (batch === null) batch = Batch.ensure();
+
 		// any effects that were previously deferred should be transferred
 		// to the batch, which will flush in the next microtask
 		batch.transfer_effects(this.#dirty_effects, this.#maybe_dirty_effects);

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -17,6 +17,7 @@ import {
 	ERROR_VALUE,
 	MANAGED_EFFECT,
 	REACTION_RAN,
+	REACTION_IS_UPDATING,
 	DESTROYING
 } from '#client/constants';
 import { async_mode_flag } from '../../flags/index.js';
@@ -1011,6 +1012,23 @@ export class Batch {
  * @returns {T}
  */
 export function flushSync(fn) {
+	// If we're still constructing the effect tree (e.g. `flushSync` called at the
+	// top of a component script, while the enclosing branch effect's update is in
+	// flight), there is nothing user-visible to flush yet — and flushing the
+	// half-built tree corrupts it: the traverse can't reach branches that aren't
+	// attached to their parent yet, leaving their CLEAN flags unbalanced, which
+	// makes every later `schedule` call on effects inside them bail. The branch's
+	// in-flight update will settle the tree, and the batch flushes normally
+	// afterwards.
+	if (
+		active_effect !== null &&
+		(active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) !== 0 &&
+		(active_effect.f & REACTION_IS_UPDATING) !== 0
+	) {
+		if (fn) return fn();
+		return;
+	}
+
 	var was_flushing_sync = is_flushing_sync;
 	is_flushing_sync = true;
 

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-async/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-async/_config.js
@@ -1,0 +1,15 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, '<button>0</button>');
+
+		// No explicit flushSync after the click — the update must still propagate
+		// through the normal microtask flush.
+		/** @type {HTMLButtonElement} */ (target.querySelector('button')).click();
+		await tick();
+
+		assert.htmlEqual(target.innerHTML, '<button>1</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-async/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-async/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	let count = $state(0);
+
+	flushSync();
+</script>
+
+<button onclick={() => count++}>{count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-pre-effect/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-pre-effect/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target, logs }) {
+		// $effect.pre must have run during init, despite the top-level flushSync
+		assert.deepEqual(logs, ['pre ran']);
+		assert.htmlEqual(target.innerHTML, '<button>0</button>');
+
+		/** @type {HTMLButtonElement} */ (target.querySelector('button')).click();
+		flushSync();
+
+		// reactivity must still work after the top-level flushSync
+		assert.htmlEqual(target.innerHTML, '<button>1</button>');
+		assert.deepEqual(logs, ['pre ran']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-pre-effect/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level-pre-effect/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	let count = $state(0);
+
+	$effect.pre(() => {
+		console.log('pre ran');
+	});
+
+	flushSync();
+</script>
+
+<button onclick={() => count++}>{count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		assert.htmlEqual(target.innerHTML, '<button>0</button>');
+
+		/** @type {HTMLButtonElement} */ (target.querySelector('button')).click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, '<button>1</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/flush-sync-top-level/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { flushSync } from 'svelte';
+
+	let count = $state(0);
+
+	flushSync();
+</script>
+
+<button onclick={() => count++}>{count}</button>


### PR DESCRIPTION
Fixes #18522

## Problem

`flushSync()` called at the top of a component's `<script>` (while the effect tree is still being constructed) had two failure modes on current main:

1. **Crash:** `Cannot read properties of null (reading 'transfer_effects')`. The mount boundary resolves against `current_batch`, but the mid-construction `flushSync` flushed the in-flight batch, whose `flush()` nulls `current_batch` in its `finally`. The boundary then read the nulled batch.
2. **Silent reactivity death:** with an `$effect.pre` (or any effect scheduled before the `flushSync`), `schedule()` toggles the enclosing branch's `CLEAN` flag to queue it — but the flush happens while that branch is still mid-creation and *not yet attached to its parent*, so the traverse can't reach it to re-clean it. The branch is left permanently not-CLEAN, and every later `schedule()` on effects inside it bails at "branch is already dirty". Clicking a button updates state but the DOM never changes.

## Fix

Two small changes in the client runtime:

- **`flushSync` skips flushing while a branch/root effect's update is in flight** (`active_effect` has `BRANCH_EFFECT | ROOT_EFFECT` + `REACTION_IS_UPDATING`). There is nothing user-visible to flush mid-construction — the mount runs synchronously anyway — and the batch flushes normally once construction settles. This prevents both the nulled batch and the unbalanced `CLEAN` flag at the source.
- **Boundary `#resolve` tolerates a null batch** (defense in depth): it transfers deferred effects into a fresh batch via `Batch.ensure()` instead of crashing, covering any other path that resolves a boundary outside a batch.

## Tests

Three new `runtime-runes` samples, all of which fail without the fix (the first two crash/thrash on mount; the third's click never updates the DOM):

- `flush-sync-top-level` — bare `flushSync()` at the top of a script: mounts, and a click still updates.
- `flush-sync-top-level-pre-effect` — `$effect.pre` + top-level `flushSync`: the pre effect runs once, and reactivity still works afterwards.
- `flush-sync-top-level-async` — no explicit `flushSync` after the click; the update must still propagate through the normal microtask flush (guards against the fix stalling future flushes).

## Test plan

```
pnpm exec vitest run packages/svelte/tests/runtime-runes/test.ts   # 2699 passed, 34 skipped
pnpm exec vitest run packages/svelte/tests/runtime-legacy/test.ts  # 3304 passed, 10 skipped
pnpm exec vitest run packages/svelte/tests/hydration packages/svelte/tests/signals  # 184 passed
pnpm exec vitest run packages/svelte/tests/motion packages/svelte/tests/store packages/svelte/tests/snapshot  # 75 passed
pnpm exec eslint packages/svelte/src/internal/client/reactivity/batch.js packages/svelte/src/internal/client/dom/blocks/boundary.js  # clean
pnpm exec prettier --check <changed files>  # clean
```

Changeset added (`svelte` patch).
