### PR TITLE
feat: add an onchange option to $state and $state.raw

### DIFF
--- a/documentation/docs/02-runes/02-$state.md
+++ b/documentation/docs/02-runes/02-$state.md
@@ -150,6 +150,20 @@ This can improve performance with large arrays and objects that you weren't plan
 
 As with `$state`, you can declare class fields using `$state.raw`.
 
+## State options
+
+`$state` and `$state.raw` accept an options object as their second argument. Its `onchange` function is called synchronously whenever the value is reassigned or, for `$state`, when any of its deeply reactive contents are mutated, before any effects run. Use it to persist state as it changes, or to constrain it:
+
+```js
+let count = $state(0, {
+	onchange() {
+		count = Math.min(count, 10);
+	}
+});
+```
+
+Reads inside `onchange` are not tracked, and a mutation it makes to its own state does not call it again.
+
 ## `$state.snapshot`
 
 To take a static snapshot of a deeply reactive `$state` proxy, use `$state.snapshot`:

--- a/packages/svelte/src/ambient.d.ts
+++ b/packages/svelte/src/ambient.d.ts
@@ -20,6 +20,11 @@ declare module '*.svelte' {
  *
  * @param initial The initial value
  */
+declare function $state<T>(
+	initial: undefined,
+	options?: import('svelte').StateOptions
+): T | undefined;
+declare function $state<T>(initial: T, options?: import('svelte').StateOptions): T;
 declare function $state<T>(initial: T): T;
 declare function $state<T>(): T | undefined;
 
@@ -130,6 +135,11 @@ declare namespace $state {
 	 *
 	 * @param initial The initial value
 	 */
+	export function raw<T>(
+		initial: undefined,
+		options?: import('svelte').StateOptions
+	): T | undefined;
+	export function raw<T>(initial?: T, options?: import('svelte').StateOptions): T;
 	export function raw<T>(initial: T): T;
 	export function raw<T>(): T | undefined;
 	/**

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/CallExpression.js
@@ -127,8 +127,8 @@ export function CallExpression(node, context) {
 
 			if ((rune === '$derived' || rune === '$derived.by') && node.arguments.length !== 1) {
 				e.rune_invalid_arguments_length(node, rune, 'exactly one argument');
-			} else if (node.arguments.length > 1) {
-				e.rune_invalid_arguments_length(node, rune, 'zero or one arguments');
+			} else if (node.arguments.length > 2) {
+				e.rune_invalid_arguments_length(node, rune, 'at most two arguments');
 			}
 
 			break;

--- a/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/transform-client.js
@@ -289,8 +289,8 @@ export function client_component(analysis, options) {
 		}
 
 		if (binding?.kind === 'state' || binding?.kind === 'raw_state') {
-			const value = binding.kind === 'state' ? b.call('$.proxy', b.id('$$value')) : b.id('$$value');
-			return [getter, b.set(alias ?? name, [b.stmt(b.call('$.set', b.id(name), value))])];
+			const call = b.call('$.set', b.id(name), b.id('$$value'), binding.kind === 'state' && b.true);
+			return [getter, b.set(alias ?? name, [b.stmt(call)])];
 		}
 
 		return getter;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/CallExpression.js
@@ -5,6 +5,7 @@ import * as b from '#compiler/builders';
 import { get_rune } from '../../../scope.js';
 import { should_proxy } from '../utils.js';
 import { get_inspect_args } from '../../utils.js';
+import { get_onchange, with_onchange } from './shared/state.js';
 
 /**
  * @param {CallExpression} node
@@ -40,7 +41,11 @@ export function CallExpression(node, context) {
 			}
 
 			const callee = b.id('$.state', node.callee.loc);
-			return b.call(callee, value);
+			const onchange = get_onchange(
+				/** @type {Expression | undefined} */ (node.arguments[1]),
+				context
+			);
+			return with_onchange(b.call(callee, value), onchange);
 		}
 
 		case '$derived':

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -14,6 +14,7 @@ import {
 	should_proxy
 } from '../utils.js';
 import { get_value } from './shared/declarations.js';
+import { get_onchange, with_onchange } from './shared/state.js';
 
 /**
  * @param {VariableDeclaration} node
@@ -130,6 +131,7 @@ export function VariableDeclaration(node, context) {
 
 			const args = /** @type {CallExpression} */ (init).arguments;
 			const value = /** @type {Expression} */ (args[0]) ?? b.void0; // TODO do we need the void 0? can we just omit it altogether?
+			const onchange = get_onchange(/** @type {Expression | undefined} */ (args[1]), context);
 
 			if (rune === '$state' || rune === '$state.raw') {
 				/**
@@ -144,7 +146,8 @@ export function VariableDeclaration(node, context) {
 					const is_proxy = should_proxy(value, context.state.scope);
 
 					if (rune === '$state' && is_proxy) {
-						value = b.call('$.proxy', value);
+						// a proxy that is never reassigned has no source, so the callback attaches to the proxy itself
+						value = is_state ? b.call('$.proxy', value) : b.call('$.proxy', value, onchange);
 
 						if (dev && !is_state) {
 							value = b.call('$.tag_proxy', value, b.literal(id.name));
@@ -158,6 +161,8 @@ export function VariableDeclaration(node, context) {
 						if (dev) {
 							value = b.call('$.tag', value, b.literal(id.name));
 						}
+
+						value = with_onchange(value, onchange);
 					}
 
 					return value;

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/state.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/shared/state.js
@@ -1,0 +1,34 @@
+/** @import { Expression, Property } from 'estree' */
+/** @import { ComponentContext, Context } from '../../types' */
+import * as b from '#compiler/builders';
+
+/**
+ * The `onchange` callback from a `$state` rune's options argument, if any
+ * @param {Expression | undefined} options the rune's second argument
+ * @param {ComponentContext | Context} context
+ * @returns {Expression | undefined}
+ */
+export function get_onchange(options, context) {
+	if (options?.type !== 'ObjectExpression') return;
+
+	const property = options.properties.find(
+		(property) =>
+			property.type === 'Property' &&
+			!property.computed &&
+			property.key.type === 'Identifier' &&
+			property.key.name === 'onchange'
+	);
+
+	if (property === undefined) return;
+
+	return /** @type {Expression} */ (context.visit(/** @type {Property} */ (property).value));
+}
+
+/**
+ * Wraps a `$.state(...)` call so `onchange` is registered on the source
+ * @param {Expression} call
+ * @param {Expression | undefined} onchange
+ */
+export function with_onchange(call, onchange) {
+	return onchange === undefined ? call : b.call('$.onchange', call, onchange);
+}

--- a/packages/svelte/src/index.d.ts
+++ b/packages/svelte/src/index.d.ts
@@ -374,4 +374,6 @@ export interface Fork {
 	discard(): void;
 }
 
+export type { StateOptions } from './internal/client/types.js';
+
 export * from './index-client.js';

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -72,6 +72,7 @@ export const COMPONENT_SYMBOL = Symbol('component');
 export const LEGACY_PROPS = Symbol('legacy props');
 export const LOADING_ATTR_SYMBOL = Symbol('');
 export const PROXY_PATH_SYMBOL = Symbol('proxy path');
+export const PROXY_META_SYMBOL = Symbol('proxy meta');
 export const ATTRIBUTES_CACHE = Symbol('attributes');
 export const CLASS_CACHE = Symbol('class');
 export const STYLE_CACHE = Symbol('style');

--- a/packages/svelte/src/internal/client/index.js
+++ b/packages/svelte/src/internal/client/index.js
@@ -131,7 +131,15 @@ export {
 	user_effect,
 	user_pre_effect
 } from './reactivity/effects.js';
-export { mutable_source, mutate, set, state, update, update_pre } from './reactivity/sources.js';
+export {
+	mutable_source,
+	mutate,
+	set,
+	state,
+	update,
+	update_pre,
+	onchange
+} from './reactivity/sources.js';
 export {
 	prop,
 	rest_props,

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -1,4 +1,4 @@
-/** @import { Source } from '#client' */
+/** @import { Effect, Source } from '#client' */
 import { DEV } from 'esm-env';
 import {
 	get,
@@ -6,8 +6,10 @@ import {
 	update_version,
 	active_reaction,
 	set_update_version,
-	set_active_reaction
+	set_active_reaction,
+	untrack
 } from './runtime.js';
+import { destroy_effect, eager_effect } from './reactivity/effects.js';
 import {
 	array_prototype,
 	get_descriptor,
@@ -22,7 +24,7 @@ import {
 	flush_eager_effects,
 	set_eager_effects_deferred
 } from './reactivity/sources.js';
-import { COMPONENT_SYMBOL, PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
+import { COMPONENT_SYMBOL, PROXY_META_SYMBOL, PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
 import { tag } from './dev/tracing.js';
@@ -33,18 +35,204 @@ import { tracing_mode_flag } from '../flags/index.js';
 const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
 /**
+ * @typedef {{
+ *   self: any;
+ *   sources: Map<any, Source<any>>;
+ *   links: Array<{ pm: ProxyMeta, k: any }>;
+ *   fires: Array<{ cb: () => void, fire: () => void, e: Effect }>;
+ *   observed: boolean;
+ * }} ProxyMeta
+ */
+
+/**
+ * Creates the dispatch half of an `onchange` root: a notifier source paired with an
+ * eager effect, so callbacks run synchronously inside `set()` and inherit the existing
+ * fork gating and deferral behaviour. The original callback is kept alongside so it
+ * can be detached again by identity
+ * @param {() => void} onchange
+ * @returns {{ cb: () => void, fire: () => void, e: Effect }}
+ */
+function create_fire(onchange) {
+	var notifier = source(0);
+	var initial = true;
+	var running = false;
+
+	var effect = eager_effect(() => {
+		get(notifier);
+
+		if (initial) {
+			initial = false;
+			return;
+		}
+
+		// guard against the callback synchronously mutating its own tree
+		if (running) return;
+		running = true;
+
+		try {
+			untrack(onchange);
+		} finally {
+			running = false;
+		}
+	});
+
+	return { cb: onchange, fire: () => increment(notifier), e: effect };
+}
+
+/**
+ * Registers `parent_meta[key]` as a (possibly stale) way to reach a root from `child`.
+ * Links are never eagerly removed — they are verified and pruned during `collect_roots`
+ * @param {any} child
+ * @param {ProxyMeta} parent_meta
+ * @param {any} key
+ */
+function link_child(child, parent_meta, key) {
+	if (child === null || typeof child !== 'object' || !(STATE_SYMBOL in child)) return;
+
+	var meta = /** @type {ProxyMeta | undefined} */ (child[PROXY_META_SYMBOL]);
+	if (meta === undefined) return;
+
+	var links = meta.links;
+
+	for (var i = 0; i < links.length; i += 1) {
+		if (links[i].pm === parent_meta && links[i].k === key) return;
+	}
+
+	links.push({ pm: parent_meta, k: key });
+	observe(meta);
+}
+
+/**
+ * Marks a node observed and links its already-materialized children, so references
+ * captured before the node joined an observed tree still reach a root
+ * @param {ProxyMeta} meta
+ */
+function observe(meta) {
+	if (meta.observed) return;
+	meta.observed = true;
+
+	for (var [key, s] of meta.sources) {
+		if (s.v !== UNINITIALIZED) {
+			link_child(s.v, meta, key);
+		}
+	}
+}
+
+/**
+ * Walks rootward from `meta`, verifying each link against the parent's backing source
+ * (`parent.sources.get(key).v === child`). Dead links are pruned in place; live chains
+ * contribute their root callbacks to `fires`
+ * @param {ProxyMeta} meta
+ * @param {Set<ProxyMeta>} visited
+ * @param {Set<() => void>} fires
+ */
+function collect_roots(meta, visited, fires) {
+	if (visited.has(meta)) return;
+	visited.add(meta);
+
+	for (var i = 0; i < meta.fires.length; i += 1) {
+		fires.add(meta.fires[i].fire);
+	}
+
+	var links = meta.links;
+
+	for (var j = links.length - 1; j >= 0; j -= 1) {
+		var link = links[j];
+		var s = link.pm.sources.get(link.k);
+
+		if (
+			s !== undefined &&
+			(s.v === meta.self ||
+				// the slot may hold a user wrapper around this proxy, which forwards the meta lookup
+				(s.v !== null &&
+					typeof s.v === 'object' &&
+					STATE_SYMBOL in s.v &&
+					/** @type {any} */ (s.v)[PROXY_META_SYMBOL] === meta))
+		) {
+			collect_roots(link.pm, visited, fires);
+		} else {
+			links.splice(j, 1);
+		}
+	}
+
+	if (links.length === 0 && meta.fires.length === 0) {
+		meta.observed = false;
+	}
+}
+
+/** @param {ProxyMeta} meta */
+function notify_onchange(meta) {
+	/** @type {Set<() => void>} */
+	var fires = new Set();
+	collect_roots(meta, new Set(), fires);
+
+	for (var fire of fires) fire();
+}
+
+/**
+ * Detaches a callback previously attached with `proxy(value, onchange)`, used by the
+ * `$state` shell so a reassigned variable's old tree stops firing its callback
+ * @param {any} value
+ * @param {() => void} onchange
+ */
+export function remove_onchange(value, onchange) {
+	if (value === null || typeof value !== 'object' || !(STATE_SYMBOL in value)) return;
+
+	var meta = /** @type {ProxyMeta | undefined} */ (value[PROXY_META_SYMBOL]);
+	if (meta === undefined) return;
+
+	var fires = meta.fires;
+
+	for (var i = 0; i < fires.length; i += 1) {
+		if (fires[i].cb === onchange) {
+			destroy_effect(fires[i].e);
+			fires.splice(i, 1);
+			break;
+		}
+	}
+
+	if (fires.length === 0 && meta.links.length === 0) {
+		meta.observed = false;
+	}
+}
+
+/**
+ * Wraps an array mutating method so onchange roots fire once per method call
+ * rather than once per internal `set` (e.g. `push` writes an element and `length`)
+ * @param {Function} fn
+ */
+function batch_eager_method(fn) {
+	return function (/** @type {any[]} */ ...args) {
+		set_eager_effects_deferred();
+
+		try {
+			// @ts-ignore
+			return fn.apply(this, args);
+		} finally {
+			flush_eager_effects();
+		}
+	};
+}
+
+/**
  * @template T
  * @param {T} value
+ * @param {() => void} [onchange] fires synchronously when anything in the proxied tree changes. Only plain objects and arrays are proxied, so writes inside class instances or reactive built-ins like `SvelteMap` do not notify
  * @returns {T}
  */
-export function proxy(value) {
-	// if non-proxyable, a component instance, or already a proxy, return `value`
-	if (
-		typeof value !== 'object' ||
-		value === null ||
-		STATE_SYMBOL in value ||
-		COMPONENT_SYMBOL in value
-	) {
+export function proxy(value, onchange) {
+	// if non-proxyable or a component instance, return `value`
+	if (typeof value !== 'object' || value === null || COMPONENT_SYMBOL in value) {
+		return value;
+	}
+
+	if (STATE_SYMBOL in value) {
+		if (onchange !== undefined) {
+			// attach an additional root callback to an existing proxy
+			var m = /** @type {ProxyMeta} */ (/** @type {any} */ (value)[PROXY_META_SYMBOL]);
+			m.fires.push(create_fire(onchange));
+			observe(m);
+		}
 		return value;
 	}
 
@@ -58,6 +246,13 @@ export function proxy(value) {
 	var sources = new Map();
 	var is_proxied_array = is_array(value);
 	var version = source(0);
+
+	/**
+	 * Only allocated once this proxy participates in an observed tree —
+	 * proxies outside onchange trees never pay for this beyond a null check
+	 * @type {ProxyMeta | null}
+	 */
+	var meta = null;
 
 	var stack = DEV && tracing_mode_flag ? get_error('created at') : null;
 	var parent_version = update_version;
@@ -115,7 +310,7 @@ export function proxy(value) {
 		updating = false;
 	}
 
-	return new Proxy(/** @type {any} */ (value), {
+	var p = new Proxy(/** @type {any} */ (value), {
 		defineProperty(_, prop, descriptor) {
 			if (
 				!('value' in descriptor) ||
@@ -148,20 +343,27 @@ export function proxy(value) {
 
 		deleteProperty(target, prop) {
 			var s = sources.get(prop);
+			var changed = false;
 
 			if (s === undefined) {
 				if (prop in target) {
 					const s = with_parent(() => source(UNINITIALIZED, stack));
 					sources.set(prop, s);
 					increment(version);
+					changed = true;
 
 					if (DEV) {
 						tag(s, get_label(path, prop));
 					}
 				}
 			} else {
+				if (s.v !== UNINITIALIZED) changed = true;
 				set(s, UNINITIALIZED);
 				increment(version);
+			}
+
+			if (changed && meta !== null && meta.observed) {
+				notify_onchange(/** @type {ProxyMeta} */ (meta));
 			}
 
 			return true;
@@ -178,6 +380,11 @@ export function proxy(value) {
 
 			var s = sources.get(prop);
 			var exists = prop in target;
+
+			// symbols are never own properties, so this check can live off the hot path
+			if (s === undefined && prop === PROXY_META_SYMBOL) {
+				return (meta ??= { self: p, sources, links: [], fires: [], observed: false });
+			}
 
 			// create a source, but only if it's an own property and not a prototype property
 			if (s === undefined && (!exists || get_descriptor(target, prop)?.writable)) {
@@ -197,10 +404,30 @@ export function proxy(value) {
 
 			if (s !== undefined) {
 				var v = get(s);
+
+				// reads through an observed proxy establish (or refresh) the child's rootward link
+				if (meta !== null && meta.observed && v !== UNINITIALIZED) {
+					link_child(v, meta, prop);
+				}
+
 				return v === UNINITIALIZED ? undefined : v;
 			}
 
-			return Reflect.get(target, prop, receiver);
+			var reflected = Reflect.get(target, prop, receiver);
+
+			if (
+				meta !== null &&
+				meta.observed &&
+				is_proxied_array &&
+				typeof prop === 'string' &&
+				typeof reflected === 'function' &&
+				ARRAY_MUTATING_METHODS.has(prop)
+			) {
+				// batch array methods so e.g. `push` (element + length) fires roots once
+				return batch_eager_method(reflected);
+			}
+
+			return reflected;
 		},
 
 		getOwnPropertyDescriptor(target, prop) {
@@ -208,12 +435,22 @@ export function proxy(value) {
 
 			if (descriptor && 'value' in descriptor) {
 				var s = sources.get(prop);
-				if (s) descriptor.value = get(s);
+				if (s) {
+					descriptor.value = get(s);
+
+					if (meta !== null && meta.observed) {
+						link_child(descriptor.value, meta, prop);
+					}
+				}
 			} else if (descriptor === undefined) {
 				var source = sources.get(prop);
 				var value = source?.v;
 
 				if (source !== undefined && value !== UNINITIALIZED) {
+					if (meta !== null && meta.observed) {
+						link_child(value, meta, prop);
+					}
+
 					return {
 						enumerable: true,
 						configurable: true,
@@ -257,6 +494,10 @@ export function proxy(value) {
 				if (value === UNINITIALIZED) {
 					return false;
 				}
+
+				if (meta !== null && meta.observed) {
+					link_child(value, meta, prop);
+				}
 			}
 
 			return has;
@@ -265,6 +506,7 @@ export function proxy(value) {
 		set(target, prop, value, receiver) {
 			var s = sources.get(prop);
 			var has = prop in target;
+			var changed = false;
 
 			// variable.length = value -> clear all signals with index >= value
 			if (is_proxied_array && prop === 'length') {
@@ -297,7 +539,14 @@ export function proxy(value) {
 					if (DEV) {
 						tag(s, get_label(path, prop));
 					}
-					set(s, proxy(value));
+
+					var np = proxy(value);
+					set(s, np);
+					changed = !has || target[prop] !== value;
+
+					if (meta !== null && meta.observed) {
+						link_child(np, /** @type {ProxyMeta} */ (meta), prop);
+					}
 
 					sources.set(prop, s);
 				}
@@ -305,7 +554,14 @@ export function proxy(value) {
 				has = s.v !== UNINITIALIZED;
 
 				var p = with_parent(() => proxy(value));
-				set(s, p);
+
+				if (meta !== null && meta.observed) {
+					if (s.v !== p) changed = true;
+					set(s, p);
+					link_child(p, meta, prop);
+				} else {
+					set(s, p);
+				}
 			}
 
 			var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
@@ -330,6 +586,11 @@ export function proxy(value) {
 				}
 
 				increment(version);
+				changed = true;
+			}
+
+			if (changed && meta !== null && meta.observed) {
+				notify_onchange(/** @type {ProxyMeta} */ (meta));
 			}
 
 			return true;
@@ -356,6 +617,12 @@ export function proxy(value) {
 			e.state_prototype_fixed();
 		}
 	});
+
+	if (onchange !== undefined) {
+		meta = { self: p, sources, links: [], fires: [create_fire(onchange)], observed: true };
+	}
+
+	return p;
 }
 
 /**

--- a/packages/svelte/src/internal/client/proxy.js
+++ b/packages/svelte/src/internal/client/proxy.js
@@ -6,8 +6,7 @@ import {
 	update_version,
 	active_reaction,
 	set_update_version,
-	set_active_reaction,
-	untrack
+	set_active_reaction
 } from './runtime.js';
 import { destroy_effect, eager_effect } from './reactivity/effects.js';
 import {
@@ -21,10 +20,15 @@ import {
 	state as source,
 	set,
 	increment,
-	flush_eager_effects,
-	set_eager_effects_deferred
+	set_eager_effects_deferred,
+	unset_eager_effects_deferred
 } from './reactivity/sources.js';
-import { COMPONENT_SYMBOL, PROXY_META_SYMBOL, PROXY_PATH_SYMBOL, STATE_SYMBOL } from '#client/constants';
+import {
+	COMPONENT_SYMBOL,
+	PROXY_META_SYMBOL,
+	PROXY_PATH_SYMBOL,
+	STATE_SYMBOL
+} from '#client/constants';
 import { UNINITIALIZED } from '../../constants.js';
 import * as e from './errors.js';
 import { tag } from './dev/tracing.js';
@@ -39,7 +43,7 @@ const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
  *   self: any;
  *   sources: Map<any, Source<any>>;
  *   links: Array<{ pm: ProxyMeta, k: any }>;
- *   fires: Array<{ cb: () => void, fire: () => void, e: Effect }>;
+ *   fires: Array<{ cb: () => void, n: Source<number>, e: Effect }>;
  *   observed: boolean;
  * }} ProxyMeta
  */
@@ -50,7 +54,7 @@ const regex_is_valid_identifier = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
  * fork gating and deferral behaviour. The original callback is kept alongside so it
  * can be detached again by identity
  * @param {() => void} onchange
- * @returns {{ cb: () => void, fire: () => void, e: Effect }}
+ * @returns {{ cb: () => void, n: Source<number>, e: Effect }}
  */
 function create_fire(onchange) {
 	var notifier = source(0);
@@ -69,14 +73,40 @@ function create_fire(onchange) {
 		if (running) return;
 		running = true;
 
+		// the callback is user code, not part of the effect: it may write state
+		// (which `set` forbids inside eager effects) and must not track its reads
+		var previous_reaction = active_reaction;
+		set_active_reaction(null);
+
 		try {
-			untrack(onchange);
+			onchange();
 		} finally {
+			set_active_reaction(previous_reaction);
 			running = false;
 		}
 	});
 
-	return { cb: onchange, fire: () => increment(notifier), e: effect };
+	return { cb: onchange, n: notifier, e: effect };
+}
+
+/**
+ * Whether `link` still describes where `meta.self` sits in its parent: the parent's
+ * source for that key holds this proxy, or a user wrapper that forwards to it
+ * @param {{ pm: ProxyMeta, k: any }} link
+ * @param {ProxyMeta} meta
+ */
+function is_live(link, meta) {
+	var s = link.pm.sources.get(link.k);
+	if (s === undefined) return false;
+
+	var v = s.v;
+	return (
+		v === meta.self ||
+		(v !== null &&
+			typeof v === 'object' &&
+			STATE_SYMBOL in v &&
+			/** @type {any} */ (v)[PROXY_META_SYMBOL] === meta)
+	);
 }
 
 /**
@@ -94,9 +124,22 @@ function link_child(child, parent_meta, key) {
 
 	var links = meta.links;
 
-	for (var i = 0; i < links.length; i += 1) {
-		if (links[i].pm === parent_meta && links[i].k === key) return;
+	var linked = false;
+
+	// links to this parent under other keys survive only while those slots still hold
+	// the child, so index churn (`unshift`, `sort`) cannot grow the list
+	for (var i = links.length - 1; i >= 0; i -= 1) {
+		var link = links[i];
+		if (link.pm !== parent_meta) continue;
+
+		if (link.k === key) {
+			linked = true;
+		} else if (!is_live(link, meta)) {
+			links.splice(i, 1);
+		}
 	}
+
+	if (linked) return;
 
 	links.push({ pm: parent_meta, k: key });
 	observe(meta);
@@ -119,54 +162,50 @@ function observe(meta) {
 }
 
 /**
- * Walks rootward from `meta`, verifying each link against the parent's backing source
- * (`parent.sources.get(key).v === child`). Dead links are pruned in place; live chains
- * contribute their root callbacks to `fires`
+ * Walks rootward from `meta`, verifying each link against the parent's backing source.
+ * Dead links are pruned in place; live chains contribute their root notifiers to `fires`
  * @param {ProxyMeta} meta
  * @param {Set<ProxyMeta>} visited
- * @param {Set<() => void>} fires
+ * @param {Set<Source<number>>} fires
  */
 function collect_roots(meta, visited, fires) {
 	if (visited.has(meta)) return;
 	visited.add(meta);
 
 	for (var i = 0; i < meta.fires.length; i += 1) {
-		fires.add(meta.fires[i].fire);
+		fires.add(meta.fires[i].n);
 	}
 
 	var links = meta.links;
 
 	for (var j = links.length - 1; j >= 0; j -= 1) {
-		var link = links[j];
-		var s = link.pm.sources.get(link.k);
-
-		if (
-			s !== undefined &&
-			(s.v === meta.self ||
-				// the slot may hold a user wrapper around this proxy, which forwards the meta lookup
-				(s.v !== null &&
-					typeof s.v === 'object' &&
-					STATE_SYMBOL in s.v &&
-					/** @type {any} */ (s.v)[PROXY_META_SYMBOL] === meta))
-		) {
-			collect_roots(link.pm, visited, fires);
+		if (is_live(links[j], meta)) {
+			collect_roots(links[j].pm, visited, fires);
 		} else {
 			links.splice(j, 1);
 		}
-	}
-
-	if (links.length === 0 && meta.fires.length === 0) {
-		meta.observed = false;
 	}
 }
 
 /** @param {ProxyMeta} meta */
 function notify_onchange(meta) {
-	/** @type {Set<() => void>} */
+	/** @type {Set<ProxyMeta>} */
+	var visited = new Set();
+	/** @type {Set<Source<number>>} */
 	var fires = new Set();
-	collect_roots(meta, new Set(), fires);
+	collect_roots(meta, visited, fires);
 
-	for (var fire of fires) fire();
+	if (fires.size === 0) {
+		// nothing reachable fires any more (roots detached, or every route pruned), so the
+		// whole visited region leaves the observed state instead of walking on every write
+		for (var m of visited) {
+			m.links.length = 0;
+			m.observed = false;
+		}
+		return;
+	}
+
+	for (var n of fires) increment(n);
 }
 
 /**
@@ -196,22 +235,34 @@ export function remove_onchange(value, onchange) {
 	}
 }
 
+/** @type {WeakMap<Function, Function>} */
+var batched_methods = new WeakMap();
+
 /**
- * Wraps an array mutating method so onchange roots fire once per method call
- * rather than once per internal `set` (e.g. `push` writes an element and `length`)
+ * Wraps an array mutating method so eager effects run once per method call rather than
+ * once per internal `set` (e.g. `push` writes an element and `length`). Memoised per
+ * method, so `arr.push === arr.push` holds and reads allocate nothing
  * @param {Function} fn
  */
 function batch_eager_method(fn) {
-	return function (/** @type {any[]} */ ...args) {
-		set_eager_effects_deferred();
+	var wrapped = batched_methods.get(fn);
 
-		try {
-			// @ts-ignore
-			return fn.apply(this, args);
-		} finally {
-			flush_eager_effects();
-		}
-	};
+	if (wrapped === undefined) {
+		wrapped = function (/** @type {any[]} */ ...args) {
+			set_eager_effects_deferred();
+
+			try {
+				// @ts-ignore
+				return fn.apply(this, args);
+			} finally {
+				unset_eager_effects_deferred();
+			}
+		};
+
+		batched_methods.set(fn, wrapped);
+	}
+
+	return wrapped;
 }
 
 /**
@@ -325,6 +376,8 @@ export function proxy(value, onchange) {
 				e.state_descriptors_fixed();
 			}
 			var s = sources.get(prop);
+			var changed = s === undefined || s.v !== descriptor.value;
+
 			if (s === undefined) {
 				with_parent(() => {
 					var s = source(descriptor.value, stack);
@@ -336,6 +389,11 @@ export function proxy(value, onchange) {
 				});
 			} else {
 				set(s, descriptor.value, true);
+			}
+
+			if (changed && meta !== null && meta.observed) {
+				link_child(/** @type {Source<any>} */ (sources.get(prop)).v, meta, prop);
+				notify_onchange(meta);
 			}
 
 			return true;
@@ -544,24 +602,18 @@ export function proxy(value, onchange) {
 					set(s, np);
 					changed = !has || target[prop] !== value;
 
-					if (meta !== null && meta.observed) {
-						link_child(np, /** @type {ProxyMeta} */ (meta), prop);
-					}
-
 					sources.set(prop, s);
 				}
 			} else {
 				has = s.v !== UNINITIALIZED;
 
-				var p = with_parent(() => proxy(value));
+				np = with_parent(() => proxy(value));
+				changed = s.v !== np;
+				set(s, np);
+			}
 
-				if (meta !== null && meta.observed) {
-					if (s.v !== p) changed = true;
-					set(s, p);
-					link_child(p, meta, prop);
-				} else {
-					set(s, p);
-				}
+			if (meta !== null && meta.observed) {
+				link_child(np, meta, prop);
 			}
 
 			var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
@@ -689,16 +741,7 @@ function inspectable_array(array) {
 				return value;
 			}
 
-			/**
-			 * @this {any[]}
-			 * @param {any[]} args
-			 */
-			return function (...args) {
-				set_eager_effects_deferred();
-				var result = value.apply(this, args);
-				flush_eager_effects();
-				return result;
-			};
+			return batch_eager_method(value);
 		}
 	});
 }

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -59,10 +59,19 @@ export function set_eager_effects(v) {
 	eager_effects = v;
 }
 
-let eager_effects_deferred = false;
+// a depth, so a mutating array method called from inside another keeps the outer one deferred
+let eager_effects_deferred = 0;
 
 export function set_eager_effects_deferred() {
-	eager_effects_deferred = true;
+	eager_effects_deferred += 1;
+}
+
+export function unset_eager_effects_deferred() {
+	eager_effects_deferred -= 1;
+
+	if (eager_effects_deferred === 0 && eager_effects.size > 0) {
+		flush_eager_effects();
+	}
 }
 
 /**
@@ -259,7 +268,7 @@ export function internal_set(source, value, updated_during_traversal = null) {
 			}
 		}
 
-		if (!batch.is_fork && eager_effects.size > 0 && !eager_effects_deferred) {
+		if (!batch.is_fork && eager_effects.size > 0 && eager_effects_deferred === 0) {
 			flush_eager_effects();
 		}
 	}
@@ -268,32 +277,33 @@ export function internal_set(source, value, updated_during_traversal = null) {
 }
 
 export function flush_eager_effects() {
-	eager_effects_deferred = false;
+	try {
+		for (const effect of eager_effects) {
+			// Mark clean inspect-effects as maybe dirty and then check their dirtiness
+			// instead of just updating the effects - this way we avoid overfiring.
+			if ((effect.f & CLEAN) !== 0) {
+				set_signal_status(effect, MAYBE_DIRTY);
+			}
 
-	for (const effect of eager_effects) {
-		// Mark clean inspect-effects as maybe dirty and then check their dirtiness
-		// instead of just updating the effects - this way we avoid overfiring.
-		if ((effect.f & CLEAN) !== 0) {
-			set_signal_status(effect, MAYBE_DIRTY);
+			let dirty;
+
+			try {
+				dirty = is_dirty(effect);
+			} catch {
+				// Dirty-checking can evaluate derived dependencies and throw in cases where
+				// parent effects are about to destroy this eager effect. Run the effect so
+				// its own error handling can deal with transient failures.
+				dirty = true;
+			}
+
+			if (dirty) {
+				update_effect(effect);
+			}
 		}
-
-		let dirty;
-
-		try {
-			dirty = is_dirty(effect);
-		} catch {
-			// Dirty-checking can evaluate derived dependencies and throw in cases where
-			// parent effects are about to destroy this eager effect. Run the effect so
-			// its own error handling can deal with transient failures.
-			dirty = true;
-		}
-
-		if (dirty) {
-			update_effect(effect);
-		}
+	} finally {
+		// an effect that throws must not stay queued, or the next unrelated write would rethrow it
+		eager_effects.clear();
 	}
-
-	eager_effects.clear();
 }
 
 /**

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -28,7 +28,8 @@ import {
 	ASYNC,
 	WAS_MARKED,
 	CONNECTED,
-	REACTION_IS_UPDATING
+	REACTION_IS_UPDATING,
+	STATE_SYMBOL
 } from '#client/constants';
 import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
@@ -42,7 +43,7 @@ import {
 	schedule_effect,
 	legacy_updates
 } from './batch.js';
-import { proxy } from '../proxy.js';
+import { proxy, remove_onchange } from '../proxy.js';
 import { execute_derived } from './deriveds.js';
 import { set_signal_status, update_derived_status } from './status.js';
 
@@ -189,6 +190,14 @@ export function set(source, value, should_proxy = false) {
  */
 export function internal_set(source, value, updated_during_traversal = null) {
 	if (!source.equals(value)) {
+		var callback = source.o;
+
+		if (callback !== undefined) {
+			// the old tree stops reporting to this source's callback, the new one starts
+			remove_onchange(source.v, callback);
+			attach_onchange(value, callback);
+		}
+
 		if (is_destroying_effect) {
 			old_values.set(source, value);
 		} else if (!old_values.has(source)) {
@@ -271,9 +280,49 @@ export function internal_set(source, value, updated_during_traversal = null) {
 		if (!batch.is_fork && eager_effects.size > 0 && eager_effects_deferred === 0) {
 			flush_eager_effects();
 		}
+
+		if (callback !== undefined) callback();
 	}
 
 	return value;
+}
+
+/**
+ * Registers `onchange` on a state source: it fires when the source is reassigned, and
+ * every proxy tree the source holds reports its mutations to it
+ * @template {Source} S
+ * @param {S} source
+ * @param {() => void} callback
+ * @returns {S}
+ */
+export function onchange(source, callback) {
+	var running = false;
+
+	// one guard per declaration, shared by the reassignment path and every proxy tree
+	// the source holds, so a callback that writes its own state runs once
+	source.o = () => {
+		if (running) return;
+		running = true;
+
+		try {
+			callback();
+		} finally {
+			running = false;
+		}
+	};
+
+	attach_onchange(source.v, source.o);
+	return source;
+}
+
+/**
+ * @param {unknown} value
+ * @param {() => void} callback
+ */
+function attach_onchange(value, callback) {
+	if (typeof value === 'object' && value !== null && STATE_SYMBOL in value) {
+		proxy(value, callback);
+	}
 }
 
 export function flush_eager_effects() {

--- a/packages/svelte/src/internal/client/reactivity/types.d.ts
+++ b/packages/svelte/src/internal/client/reactivity/types.d.ts
@@ -15,6 +15,11 @@ export interface Signal {
 	wv: number;
 }
 
+export interface StateOptions {
+	/** Called synchronously whenever the state is reassigned or, for `$state`, mutated anywhere in its tree */
+	onchange?: () => void;
+}
+
 export interface Value<V = unknown> extends Signal {
 	/** Equality function */
 	equals: Equals;
@@ -24,6 +29,8 @@ export interface Value<V = unknown> extends Signal {
 	rv: number;
 	/** The latest value for this signal */
 	v: V;
+	/** `onchange` callback, fired on reassignment and attached to every proxy tree this source holds */
+	o?: () => void;
 
 	// dev-only
 	/** A label (e.g. the `foo` in `let foo = $state(...)`) used for `$inspect.trace()` */

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-args/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-args/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'rune_invalid_arguments_length',
-		message: '`$state` must be called with zero or one arguments'
+		message: '`$state` must be called with at most two arguments'
 	}
 });

--- a/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/_config.js
+++ b/packages/svelte/tests/compiler-errors/samples/runes-wrong-state-raw-args/_config.js
@@ -3,6 +3,6 @@ import { test } from '../../test';
 export default test({
 	error: {
 		code: 'rune_invalid_arguments_length',
-		message: '`$state.raw` must be called with zero or one arguments'
+		message: '`$state.raw` must be called with at most two arguments'
 	}
 });

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-accumulated/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-accumulated/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2] = target.querySelectorAll('button');
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['foo', 'baz']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['foo', 'baz', 'foo', 'baz']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-accumulated/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-accumulated/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	let foo = $state({ bar: 1 }, {
+		onchange(){
+			console.log("foo");
+		}
+	});
+	let baz = $state(foo, {
+		onchange(){
+			console.log("baz");
+		}
+	})
+</script>
+
+<button onclick={()=> foo.bar++}>foo</button>
+<button onclick={()=> baz.bar++}>baz</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-after-mutate/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-after-mutate/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => btn?.click());
+		assert.deepEqual(logs, [{ message: 'hello' }, { message: 'goodbye' }]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-after-mutate/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-after-mutate/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	let object = $state(
+		{},
+		{
+			onchange() {
+				console.log($state.snapshot(object));
+			}
+		}
+	);
+
+	object.message = 'hello';
+</script>
+
+<button onclick={() => object.message = 'goodbye'}>goodbye</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-array-length-batch/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-array-length-batch/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2] = target.querySelectorAll('button');
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, [[{}, {}, {}, {}, {}, {}, {}, {}]]);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, [[{}, {}, {}, {}, {}, {}, {}, {}], []]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-array-length-batch/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-array-length-batch/main.svelte
@@ -1,0 +1,14 @@
+<script>
+	let array = $state([], {
+		onchange() {
+			console.log($state.snapshot(array));
+		}
+	});
+</script>
+
+<!-- clicking either of these buttons should result in at most one log -->
+<button onclick={() => array = [{}, {}, {}, {}, {}, {}, {}, {}]}>populate array</button>
+<button onclick={() => array.length = 0}>clear array</button>
+
+<!-- without this, nested proxies aren't created -->
+<pre>{JSON.stringify(array)}</pre>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-arrays/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-arrays/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2, btn3] = target.querySelectorAll('button');
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['arr']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['arr', 'arr']);
+
+		flushSync(() => btn3.click());
+		assert.deepEqual(logs, ['arr', 'arr', 'arr']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-arrays/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-arrays/main.svelte
@@ -1,0 +1,11 @@
+<script>
+	let arr = $state([0,1,2], {
+		onchange(){
+			console.log("arr");
+		}
+	})
+</script>
+
+<button onclick={()=> arr.push(arr.length)}>push</button>
+<button onclick={()=>arr.splice(0, 2)}>splice</button>
+<button onclick={()=>arr.sort((a,b)=>b-a)}>sort</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-child/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-child/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => btn?.click());
+		assert.deepEqual(logs, ['b changed']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-child/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-child/main.svelte
@@ -1,0 +1,13 @@
+<script>
+	let a = $state({});
+
+	let b = $state({ count: 0 }, {
+		onchange() {
+			console.log('b changed');
+		}
+	});
+
+	a.b = b;
+</script>
+
+<button onclick={()=> b.count++}>{b.count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-classes/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-classes/_config.js
@@ -1,0 +1,64 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2, btn3, btn4, btn5, btn6, btn7] = target.querySelectorAll('button');
+
+		assert.deepEqual(logs, [
+			'constructor count',
+			'constructor proxy',
+			'assign in constructor',
+			'assign in constructor proxy'
+		]);
+
+		logs.length = 0;
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['class count']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['class count', 'class proxy']);
+
+		flushSync(() => btn3.click());
+		assert.deepEqual(logs, ['class count', 'class proxy', 'class proxy']);
+
+		flushSync(() => btn4.click());
+		assert.deepEqual(logs, [
+			'class count',
+			'class proxy',
+			'class proxy',
+			'declared in constructor'
+		]);
+
+		flushSync(() => btn5.click());
+		assert.deepEqual(logs, [
+			'class count',
+			'class proxy',
+			'class proxy',
+			'declared in constructor',
+			'declared in constructor'
+		]);
+
+		flushSync(() => btn6.click());
+		assert.deepEqual(logs, [
+			'class count',
+			'class proxy',
+			'class proxy',
+			'declared in constructor',
+			'declared in constructor',
+			'declared in constructor proxy'
+		]);
+
+		flushSync(() => btn7.click());
+		assert.deepEqual(logs, [
+			'class count',
+			'class proxy',
+			'class proxy',
+			'declared in constructor',
+			'declared in constructor',
+			'declared in constructor proxy',
+			'declared in constructor proxy'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-classes/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-classes/main.svelte
@@ -1,0 +1,68 @@
+<script>
+	class Test{
+		count = $state(0, {
+			onchange(){
+				console.log("class count");
+			}
+		})
+		proxy = $state({count: 0}, {
+			onchange(){
+				console.log("class proxy");
+			}
+		})
+
+		#in_constructor = $state(0, {
+			onchange(){
+				console.log("constructor count");
+			}
+		});
+
+		#in_constructor_proxy = $state({ count: 0 }, {
+			onchange(){
+				console.log("constructor proxy");
+			}
+		});
+
+		declared_in_constructor;
+		declared_in_constructor_proxy;
+		#assign_in_constructor;
+		#assign_in_constructor_proxy;
+
+		constructor(){
+			this.#in_constructor = 42;
+			this.#in_constructor_proxy.count++;
+			this.declared_in_constructor = $state(0, {
+				onchange(){
+					console.log("declared in constructor");
+				}
+			});
+			this.declared_in_constructor_proxy = $state({ count: 0 }, {
+				onchange(){
+					console.log("declared in constructor proxy");
+				}
+			});
+			this.#assign_in_constructor = $state(0, {
+				onchange(){
+					console.log("assign in constructor");
+				}
+			});
+			this.#assign_in_constructor++;
+			this.#assign_in_constructor_proxy = $state({ count: 0 }, {
+				onchange(){
+					console.log("assign in constructor proxy");
+				}
+			});
+			this.#assign_in_constructor_proxy.count++;
+		}
+	}
+
+	const class_test = new Test();
+</script>
+
+<button onclick={()=> class_test.count++}>{class_test.count}</button>
+<button onclick={()=> class_test.proxy.count++}>{class_test.proxy.count}</button>
+<button onclick={()=> class_test.proxy = {count: class_test.proxy.count+1}}>{class_test.proxy.count}</button>
+<button onclick={()=> class_test.declared_in_constructor++}>{class_test.declared_in_constructor}</button>
+<button onclick={()=> class_test.declared_in_constructor = class_test.declared_in_constructor + 1 }>{class_test.declared_in_constructor}</button>
+<button onclick={()=> class_test.declared_in_constructor_proxy.count++}>{class_test.declared_in_constructor_proxy.count}</button>
+<button onclick={()=> class_test.declared_in_constructor_proxy.count = class_test.declared_in_constructor_proxy.count + 1 }>{class_test.declared_in_constructor_proxy.count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-extrapolated-reference/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-extrapolated-reference/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2, btn3, btn4, btn5, btn6] = target.querySelectorAll('button');
+		logs.length = 0;
+
+		flushSync(() => btn.click());
+		flushSync(() => btn2.click());
+		flushSync(() => btn3.click());
+		flushSync(() => btn4.click());
+		flushSync(() => btn5.click());
+		assert.deepEqual(logs, []);
+
+		flushSync(() => btn6.click());
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['arr', 'arr']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-extrapolated-reference/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-extrapolated-reference/main.svelte
@@ -1,0 +1,43 @@
+<script>
+	let arr = $state([{ count: 1 }, { count: 1 }], {
+		onchange(){
+			console.log("arr");
+		}
+	});
+
+	const item = arr.pop();
+
+	const item_2 = arr[0];
+
+	arr[0] = { count: 1 };
+
+	let obj = $state({ value: { count: 0 }, key: { count: 0 } }, {
+		onchange(){
+			console.log("obj");
+		}
+	});
+
+	const item_3 = obj.value;
+	delete obj.value;
+
+	const values = [...Object.values(obj)];
+
+	delete obj.key;
+
+	let arr_2 = $state([{ count: 1 }, { count: 1 }], {
+		onchange(){
+			console.log("arr_2");
+		}
+	});
+
+	const item_4 = arr_2[0];
+
+	arr_2.length = 0;
+</script>
+
+<button onclick={()=> item.count++}>{item.count}</button>
+<button onclick={()=> item_2.count++}>{item_2.count}</button>
+<button onclick={()=> item_3.count++}>{item_3.count}</button>
+<button onclick={()=> values[0].count++}>{values[0].count}</button>
+<button onclick={()=> item_4.count++}>{item_4.count}</button>
+<button onclick={()=> arr.push(item)}>push</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-proxies/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-proxies/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2] = target.querySelectorAll('button');
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['proxy']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['proxy', 'proxy']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-proxies/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-proxies/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let proxy = $state({count: 0}, {
+		onchange(){
+			console.log("proxy");
+		}
+	})
+</script>
+
+<button onclick={()=> proxy.count++}>{proxy.count}</button>
+<button onclick={()=> proxy = {count: proxy.count+1}}>{proxy.count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-reassign-proxy/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-reassign-proxy/_config.js
@@ -1,0 +1,20 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2, btn3, btn4] = target.querySelectorAll('button');
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['a']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['a', 'b', 'c']);
+		flushSync(() => btn3.click());
+		assert.deepEqual(logs, ['a', 'b', 'c', 'b', 'c']);
+		flushSync(() => btn4.click());
+		assert.deepEqual(logs, ['a', 'b', 'c', 'b', 'c', 'c']);
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['a', 'b', 'c', 'b', 'c', 'c', 'b']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-reassign-proxy/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-reassign-proxy/main.svelte
@@ -1,0 +1,27 @@
+<script>
+	let obj = { count: 0 };
+
+	let a = $state(obj, {
+	  onchange() {
+	    console.log('a');
+	  }
+	});
+	
+	let b = $state(obj, {
+	  onchange() {
+	    console.log('b');
+	  }
+	});
+	
+	let c = $state(b, {
+	  onchange() {
+	    console.log('c');
+	  }
+	});
+</script>
+
+<button onclick={()=> a.count++}>{a.count}</button>
+<button onclick={()=> b.count++}>{b.count}</button> 
+<button onclick={()=> c.count++}>{c.count}</button> 
+
+<button onclick={() => c = { count: c.count }}>unlink</button> 

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-self-reassign/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-self-reassign/_config.js
@@ -1,0 +1,17 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [count, items] = target.querySelectorAll('button');
+
+		flushSync(() => count.click());
+		assert.deepEqual(logs, ['count', 20]);
+		assert.htmlEqual(count.innerHTML, '10');
+
+		logs.length = 0;
+		flushSync(() => items.click());
+		assert.deepEqual(logs, ['items', 3]);
+		assert.htmlEqual(items.innerHTML, '2');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange-self-reassign/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange-self-reassign/main.svelte
@@ -1,0 +1,18 @@
+<script>
+	let count = $state(0, {
+		onchange() {
+			console.log('count', count);
+			count = Math.min(count, 10);
+		}
+	});
+
+	let items = $state([], {
+		onchange() {
+			console.log('items', items.length);
+			if (items.length > 2) items.length = 2;
+		}
+	});
+</script>
+
+<button onclick={() => (count = 20)}>{count}</button>
+<button onclick={() => items.push(1, 2, 3)}>{items.length}</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange/_config.js
@@ -1,0 +1,11 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const btn = target.querySelector('button');
+
+		flushSync(() => btn?.click());
+		assert.deepEqual(logs, ['count']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-onchange/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-onchange/main.svelte
@@ -1,0 +1,9 @@
+<script>
+	let count = $state(0, {
+		onchange(){
+			console.log("count");
+		}
+	})
+</script>
+
+<button onclick={()=> count++}>{count}</button>

--- a/packages/svelte/tests/runtime-runes/samples/state-raw-onchange/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-raw-onchange/_config.js
@@ -1,0 +1,106 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const [btn, btn2, btn3, btn4, btn5, btn6, btn7, btn8, btn9, btn10, btn11, btn12, btn13] =
+			target.querySelectorAll('button');
+
+		assert.deepEqual(logs, [
+			'constructor count',
+			'constructor object',
+			'assign in constructor',
+			'assign in constructor object'
+		]);
+
+		logs.length = 0;
+
+		flushSync(() => btn.click());
+		assert.deepEqual(logs, ['count']);
+
+		flushSync(() => btn2.click());
+		assert.deepEqual(logs, ['count']);
+
+		flushSync(() => btn3.click());
+		assert.deepEqual(logs, ['count', 'object']);
+
+		flushSync(() => btn4.click());
+		assert.deepEqual(logs, ['count', 'object', 'class count']);
+
+		flushSync(() => btn5.click());
+		assert.deepEqual(logs, ['count', 'object', 'class count']);
+
+		flushSync(() => btn6.click());
+		assert.deepEqual(logs, ['count', 'object', 'class count', 'class object']);
+
+		flushSync(() => btn7.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor'
+		]);
+
+		flushSync(() => btn8.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object'
+		]);
+
+		flushSync(() => btn9.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object'
+		]);
+
+		flushSync(() => btn10.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object'
+		]);
+
+		flushSync(() => btn11.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object'
+		]);
+
+		flushSync(() => btn12.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object'
+		]);
+
+		flushSync(() => btn13.click());
+		assert.deepEqual(logs, [
+			'count',
+			'object',
+			'class count',
+			'class object',
+			'declared in constructor',
+			'declared in constructor object',
+			'arr'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-raw-onchange/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-raw-onchange/main.svelte
@@ -1,0 +1,94 @@
+<script>
+	let count = $state.raw(0, {
+		onchange(){
+			console.log("count");
+		}
+	})
+
+	let object = $state.raw({count: 0}, {
+		onchange(){
+			console.log("object");
+		}
+	})
+
+	class Test{
+		count = $state.raw(0, {
+			onchange(){
+				console.log("class count");
+			}
+		})
+		object = $state.raw({count: 0}, {
+			onchange(){
+				console.log("class object");
+			}
+		})
+
+		#in_constructor = $state.raw(0, {
+			onchange(){
+				console.log("constructor count");
+			}
+		});
+
+		#in_constructor_obj = $state.raw({ count: 0 }, {
+			onchange(){
+				console.log("constructor object");
+			}
+		});
+
+		declared_in_constructor;
+		declared_in_constructor_obj;
+		#assign_in_constructor;
+		#assign_in_constructor_obj;
+
+		constructor(){
+			this.#in_constructor++;
+			this.#in_constructor_obj = { count: this.#in_constructor_obj.count + 1 };
+			this.declared_in_constructor = $state.raw(0, {
+				onchange(){
+					console.log("declared in constructor");
+				}
+			});
+			this.declared_in_constructor_obj = $state.raw({ count: 0 }, {
+				onchange(){
+					console.log("declared in constructor object");
+				}
+			});
+			this.#assign_in_constructor = $state.raw(0, {
+				onchange(){
+					console.log("assign in constructor");
+				}
+			});
+			this.#assign_in_constructor++;
+			this.#assign_in_constructor_obj = $state.raw({ count: 0 }, {
+				onchange(){
+					console.log("assign in constructor object");
+				}
+			});
+			this.#assign_in_constructor_obj = { count: this.#assign_in_constructor_obj.count + 1 };
+		}
+	}
+
+	const class_test = new Test();
+
+	let arr = $state.raw([0,1,2], {
+		onchange(){
+			console.log("arr");
+		}
+	})
+</script>
+
+<button onclick={()=> count++}>{count}</button>
+<button onclick={()=> object.count++}>{object.count}</button>
+<button onclick={()=> object = {count: object.count+1}}>{object.count}</button>
+
+<button onclick={()=> class_test.count++}>{class_test.count}</button>
+<button onclick={()=> class_test.object.count++}>{class_test.object.count}</button>
+<button onclick={()=> class_test.object = {count: class_test.object.count+1}}>{class_test.object.count}</button>
+<button onclick={()=> class_test.declared_in_constructor++}>{class_test.declared_in_constructor}</button>
+<button onclick={()=> class_test.declared_in_constructor_obj = {count: class_test.declared_in_constructor_obj.count + 1}}>{class_test.declared_in_constructor_obj.count}</button>
+<button onclick={()=> class_test.declared_in_constructor_obj.count++}>{class_test.declared_in_constructor_obj.count}</button>
+
+<button onclick={()=> arr.push(arr.length)}>push</button>
+<button onclick={()=>arr.splice(0, 2)}>splice</button>
+<button onclick={()=>arr.sort((a,b)=>b-a)}>sort</button>
+<button onclick={()=>arr = []}>assign</button>

--- a/packages/svelte/tests/signals/onchange.test.ts
+++ b/packages/svelte/tests/signals/onchange.test.ts
@@ -1,0 +1,298 @@
+import { assert, describe, it } from 'vitest';
+import { effect_root } from '../../src/internal/client/reactivity/effects';
+import { push, pop } from '../../src/internal/client/context';
+import { proxy, remove_onchange } from '../../src/internal/client/proxy';
+
+function run(fn: () => void) {
+	push({}, true);
+	const destroy = effect_root(() => {
+		fn();
+	});
+	pop();
+	destroy();
+}
+
+describe('proxy onchange kernel', () => {
+	it('fires synchronously on deep mutation', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: { b: 1 } } as any, () => count++);
+
+			state.a.b = 2;
+			assert.equal(count, 1);
+
+			state.a.b = 3;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('does not fire when a write does not change the value', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ x: 1 } as any, () => count++);
+
+			state.x = 2;
+			assert.equal(count, 1);
+
+			state.x = 2;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('veto case 1 (shared-array flaw): detached children go silent', () => {
+		run(() => {
+			let count = 0;
+			const items = proxy([{ foo: 'a' }, { foo: 'b' }, { foo: 'c' }] as any[], () => count++);
+
+			const last = items[2];
+			assert.equal(count, 0);
+
+			items.pop();
+			assert.equal(count, 1);
+
+			// the popped item is no longer in the tree — mutating it must not fire
+			last.foo = 'blah';
+			assert.equal(count, 1);
+		});
+	});
+
+	it('veto case 2 (parent-chain dealbreaker): existing proxies can join observed trees', () => {
+		run(() => {
+			let foo = 0;
+			let bar = 0;
+			const inner = proxy({ x: 0 } as any, () => bar++);
+			const tree = proxy({} as any, () => foo++);
+
+			tree.slot = inner;
+			assert.equal(foo, 1);
+			assert.equal(bar, 0);
+
+			// mutating inner through its own reference notifies BOTH trees
+			inner.x = 1;
+			assert.equal(foo, 2);
+			assert.equal(bar, 1);
+
+			// and through the tree as well
+			tree.slot.x = 2;
+			assert.equal(foo, 3);
+			assert.equal(bar, 2);
+
+			delete tree.slot;
+			assert.equal(foo, 4);
+			assert.equal(bar, 2);
+
+			// detached again — only its own root fires
+			inner.x = 3;
+			assert.equal(foo, 4);
+			assert.equal(bar, 3);
+		});
+	});
+
+	it('veto case 3 (Set aliasing bug): same child under two keys survives one deletion', () => {
+		run(() => {
+			let count = 0;
+			const tree = proxy({} as any, () => count++);
+
+			tree.a = { z: 0 };
+			assert.equal(count, 1);
+
+			tree.b = tree.a;
+			assert.equal(count, 2);
+
+			delete tree.a;
+			assert.equal(count, 3);
+
+			// still reachable via `b` — must still fire
+			tree.b.z = 1;
+			assert.equal(count, 4);
+
+			const child = tree.b;
+			delete tree.b;
+			assert.equal(count, 5);
+
+			// now fully detached — silent
+			child.z = 2;
+			assert.equal(count, 5);
+		});
+	});
+
+	it('array methods fire once per call', () => {
+		run(() => {
+			let count = 0;
+			const arr = proxy([] as any[], () => count++);
+
+			arr.push(1);
+			assert.equal(count, 1);
+
+			arr.push(2, 3);
+			assert.equal(count, 2);
+
+			arr.splice(0, 1);
+			assert.equal(count, 3);
+		});
+	});
+
+	it('works without a parent effect (module-level state)', () => {
+		let count = 0;
+		const state = proxy({ n: 0 } as any, () => count++);
+
+		state.n = 1;
+		assert.equal(count, 1);
+	});
+
+	it('lazily-read nested objects are covered once traversed', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ nested: { deep: { v: 0 } } } as any, () => count++);
+
+			// mutation requires traversal, traversal establishes links
+			state.nested.deep.v = 1;
+			assert.equal(count, 1);
+
+			const deep = state.nested.deep;
+			deep.v = 2;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('callback reads see the post-mutation tree', () => {
+		run(() => {
+			let seen = -1;
+			const state: any = proxy({ x: 0 } as any, () => (seen = state.x));
+
+			state.x = 42;
+			assert.equal(seen, 42);
+		});
+	});
+
+	it('does not fire when the first write of a property does not change it', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ x: 1 } as any, () => count++);
+
+			state.x = 1;
+			assert.equal(count, 0);
+
+			state.x = 2;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('attached callbacks can be detached again (#15069 reassignment path)', () => {
+		run(() => {
+			const logs: string[] = [];
+			const b = proxy({ count: 0 } as any, () => logs.push('b'));
+			const c = () => logs.push('c');
+			proxy(b, c);
+
+			b.count = 1;
+			assert.deepEqual(logs, ['b', 'c']);
+
+			remove_onchange(b, c);
+
+			b.count = 2;
+			assert.deepEqual(logs, ['b', 'c', 'b']);
+		});
+	});
+
+	it('attaching to an existing proxy covers already-materialized children', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: { b: 0 } } as any);
+			const a = state.a;
+
+			proxy(state, () => count++);
+
+			a.b = 1;
+			assert.equal(count, 1);
+		});
+	});
+
+	it('references captured before a subtree joins an observed tree still notify', () => {
+		run(() => {
+			let count = 0;
+			const inner = proxy({ nested: { v: 0 } } as any);
+			const captured = inner.nested;
+
+			const tree = proxy({} as any, () => count++);
+			tree.slot = inner;
+			assert.equal(count, 1);
+
+			captured.v = 1;
+			assert.equal(count, 2);
+		});
+	});
+
+	it('children created while detached are covered after re-attachment', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ child: { v: 0 } } as any, () => count++);
+
+			const child = state.child;
+			state.child = null;
+			assert.equal(count, 1);
+
+			child.v = 1;
+			child.deep = { z: 0 };
+			const deep = child.deep;
+			assert.equal(count, 1);
+
+			state.child = child;
+			assert.equal(count, 2);
+
+			deep.z = 1;
+			assert.equal(count, 3);
+		});
+	});
+
+	it('replacing a subtree detaches the old one', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ child: { v: 0 } } as any, () => count++);
+
+			const old = state.child;
+			old.v = 1;
+			assert.equal(count, 1);
+
+			state.child = { v: 100 };
+			assert.equal(count, 2);
+
+			old.v = 2;
+			assert.equal(count, 2);
+
+			state.child.v = 101;
+			assert.equal(count, 3);
+		});
+	});
+
+	it('fires through a user wrapper around a state proxy', () => {
+		run(() => {
+			let count = 0;
+			const inner = proxy({ x: 1 } as any);
+			const wrapped = new Proxy(inner, {});
+
+			const state = proxy({ slot: null } as any, () => count++);
+			state.slot = wrapped;
+			assert.equal(count, 1);
+
+			state.slot.x = 2;
+			assert.equal(count, 2);
+
+			// verification must accept the wrapper — a later write still fires
+			inner.x = 3;
+			assert.equal(count, 3);
+		});
+	});
+
+	it('links children handed out via the has trap and property descriptors', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ child: { x: 1 } } as any, () => count++);
+
+			void ('child' in state);
+			const descriptor = Object.getOwnPropertyDescriptor(state, 'child');
+			descriptor!.value.x = 2;
+			assert.equal(count, 1);
+		});
+	});
+});

--- a/packages/svelte/tests/signals/onchange.test.ts
+++ b/packages/svelte/tests/signals/onchange.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from 'vitest';
 import { effect_root } from '../../src/internal/client/reactivity/effects';
 import { push, pop } from '../../src/internal/client/context';
 import { proxy, remove_onchange } from '../../src/internal/client/proxy';
+import { PROXY_META_SYMBOL } from '../../src/internal/client/constants';
 
 function run(fn: () => void) {
 	push({}, true);
@@ -293,6 +294,105 @@ describe('proxy onchange kernel', () => {
 			const descriptor = Object.getOwnPropertyDescriptor(state, 'child');
 			descriptor!.value.x = 2;
 			assert.equal(count, 1);
+		});
+	});
+
+	it('lets the callback write state', () => {
+		run(() => {
+			const other = proxy({ n: 0 } as any);
+			const state = proxy({ a: 1 } as any, () => other.n++);
+
+			state.a = 2;
+			assert.equal(other.n, 1);
+		});
+	});
+
+	it('does not let a throwing callback break later unrelated writes', () => {
+		run(() => {
+			const a = proxy({ v: 0 } as any, () => {
+				throw new Error('boom');
+			});
+			assert.throws(() => (a.v = 1), /boom/);
+
+			const b = proxy({ v: 0 } as any);
+			b.v = 1;
+			assert.equal(b.v, 1);
+		});
+	});
+
+	it('fires once for an array method whose callback mutates another observed array', () => {
+		run(() => {
+			let count = 0;
+			const other = proxy([1] as any[]);
+			const arr = proxy([3, 1, 2] as any[], () => count++);
+
+			arr.sort((x, y) => {
+				other.push(0);
+				return x - y;
+			});
+
+			assert.equal(count, 1);
+		});
+	});
+
+	it('keeps links bounded under index churn', () => {
+		run(() => {
+			const arr = proxy([{ id: 0 }, { id: 1 }, { id: 2 }] as any[], () => {});
+			const last = arr[2];
+
+			for (let i = 3; i < 200; i += 1) {
+				arr.unshift({ id: i });
+			}
+
+			// every element was read through the array's get trap many times under shifting keys
+			for (let i = 0; i < arr.length; i += 1) arr[i];
+
+			assert.equal(last[PROXY_META_SYMBOL].links.length, 1);
+		});
+	});
+
+	it('fires for defineProperty', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: 1 } as any, () => count++);
+
+			Object.defineProperty(state, 'b', {
+				value: 2,
+				enumerable: true,
+				configurable: true,
+				writable: true
+			});
+			assert.equal(count, 1);
+			assert.equal(state.b, 2);
+		});
+	});
+
+	it('stops walking a subtree once no root can fire', () => {
+		run(() => {
+			const cb = () => {};
+			const state = proxy({ a: { b: 1 } } as any, cb);
+			const child = state.a;
+			assert.equal(child[PROXY_META_SYMBOL].observed, true);
+
+			remove_onchange(state, cb);
+			child.b = 2;
+
+			assert.equal(child[PROXY_META_SYMBOL].observed, false);
+			assert.equal(child[PROXY_META_SYMBOL].links.length, 0);
+		});
+	});
+
+	it('does not loop when the callback mutates its own tree', () => {
+		run(() => {
+			let count = 0;
+			const state = proxy({ a: 1, log: 0 } as any, () => {
+				count++;
+				state.log++;
+			});
+
+			state.a = 2;
+			assert.equal(count, 1);
+			assert.equal(state.log, 1);
 		});
 	});
 });

--- a/packages/svelte/types/index.d.ts
+++ b/packages/svelte/types/index.d.ts
@@ -458,16 +458,9 @@ declare module 'svelte' {
 	 * @deprecated Use [`$effect`](https://svelte.dev/docs/svelte/$effect) instead
 	 * */
 	export function afterUpdate(fn: () => void): void;
-	export function hydratable<T>(key: string, fn: () => T): T;
-	/**
-	 * Create a snippet programmatically
-	 * */
-	export function createRawSnippet<Params extends unknown[]>(fn: (...params: Getters<Params>) => {
-		render: () => string;
-		setup?: (element: Element) => void | (() => void);
-	}): Snippet<Params>;
-	/** Anything except a function */
-	type NotFunction<T> = T extends Function ? never : T;
+	type Getters<T> = {
+		[K in keyof T]: () => T[K];
+	};
 	/**
 	 * Synchronously flush any pending updates.
 	 * Returns void if no callback is provided, otherwise returns the result of calling the callback.
@@ -491,6 +484,20 @@ declare module 'svelte' {
 	 * @since 5.42
 	 */
 	export function fork(fn: () => void): Fork;
+	export interface StateOptions {
+		/** Called synchronously whenever the state is reassigned or, for `$state`, mutated anywhere in its tree */
+		onchange?: () => void;
+	}
+	export function hydratable<T>(key: string, fn: () => T): T;
+	/**
+	 * Create a snippet programmatically
+	 * */
+	export function createRawSnippet<Params extends unknown[]>(fn: (...params: Getters<Params>) => {
+		render: () => string;
+		setup?: (element: Element) => void | (() => void);
+	}): Snippet<Params>;
+	/** Anything except a function */
+	type NotFunction<T> = T extends Function ? never : T;
 	/**
 	 * Returns a `[get, set, has]` triplet of functions for working with context in a type-safe way.
 	 *
@@ -605,9 +612,6 @@ declare module 'svelte' {
 	 * ```
 	 * */
 	export function untrack<T>(fn: () => T): T;
-	type Getters<T> = {
-		[K in keyof T]: () => T[K];
-	};
 
 	export {};
 }
@@ -3338,6 +3342,11 @@ declare module 'svelte/types/compiler/interfaces' {
  *
  * @param initial The initial value
  */
+declare function $state<T>(
+	initial: undefined,
+	options?: import('svelte').StateOptions
+): T | undefined;
+declare function $state<T>(initial: T, options?: import('svelte').StateOptions): T;
 declare function $state<T>(initial: T): T;
 declare function $state<T>(): T | undefined;
 
@@ -3448,6 +3457,11 @@ declare namespace $state {
 	 *
 	 * @param initial The initial value
 	 */
+	export function raw<T>(
+		initial: undefined,
+		options?: import('svelte').StateOptions
+	): T | undefined;
+	export function raw<T>(initial?: T, options?: import('svelte').StateOptions): T;
 	export function raw<T>(initial: T): T;
 	export function raw<T>(): T | undefined;
 	/**


### PR DESCRIPTION
`$state(value, { onchange })` and `$state.raw(value, { onchange })` call `onchange` synchronously when the state is reassigned or, for `$state`, mutated anywhere in its tree.

Same API and tests as #15069, which stalled on deep propagation: every design kept listener bookkeeping correct at write time, so it either allocated per proxy, could not detach, or forbade sharing a proxy between trees. Here children keep possibly stale `(parent, key)` links and the walk verifies each one against the parent's source at fire time, pruning as it goes. Proxies outside an onchange tree pay a null check.

Supersedes #18537.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional synchronous `onchange` callbacks to `$state` and `$state.raw`.
  * Callbacks run when state is reassigned or when nested objects and arrays mutate.
  * Added support for callback-driven updates such as enforcing limits or logging changes.
  * Added the public `StateOptions` type and support for undefined initial state values.

* **Documentation**
  * Documented state change callbacks, including callback timing, deep mutations, and self-mutation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Draft until the explicit deep state direction settles, since `onchange` belongs on whichever rune owns deep proxies.
