### PR TITLE
fix: don't bail scheduling on a branch owned by a dropped batch

### DIFF
--- a/.changeset/fix-batch-schedule-bail.md
+++ b/.changeset/fix-batch-schedule-bail.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't bail scheduling on a branch owned by a dropped batch

--- a/packages/svelte/src/internal/client/reactivity/batch.js
+++ b/packages/svelte/src/internal/client/reactivity/batch.js
@@ -966,16 +966,25 @@ export class Batch {
 			}
 
 			if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
-				if ((flags & CLEAN) === 0) {
-					// branch is already dirty, bail
-					return;
-				}
-
+			// Mark the branch dirty if it isn't already. Previously we bailed here
+			// when the branch was already dirty, assuming some batch already had
+			// the root queued for traversal. But CLEAN/DIRTY flags live on the
+			// shared effect tree while `#roots` is per-batch, so that assumption
+			// breaks when the owning batch is dropped (e.g. after a `flushSync()`
+			// inside a render-phase effect drops a batch whose roots were already
+			// populated), leaving the root marked dirty but owned by no batch.
+			// Every later schedule() would then bail here and traverse nothing,
+			// permanently killing the root's reactivity. Instead, keep walking to
+			// the root and enqueue it (deduped) so this batch traverses it.
+			// See https://github.com/sveltejs/svelte/issues/18546
+			if ((flags & CLEAN) !== 0) {
 				e.f ^= CLEAN;
 			}
 		}
 
-		this.#roots.push(e);
+		if (!this.#roots.includes(e)) {
+			this.#roots.push(e);
+		}
 	}
 
 	#unlink() {

--- a/packages/svelte/tests/runtime-runes/samples/batch-created-during-flush-action-update/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/batch-created-during-flush-action-update/_config.js
@@ -1,0 +1,57 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+// Regression test for https://github.com/sveltejs/svelte/issues/18761
+// A state write that lands while a batch is being processed reaches
+// Batch.ensure() while is_processing is true. The batch gets created but
+// never scheduled because !is_processing && !is_flushing_sync guard skips
+// queue_micro_task. When the flush exits through #find_earlier_batch()
+// merge path, that pickup is skipped, and the batch stays unstarted forever.
+//
+// This test reproduces the bug with an action's update running during flush
+// (different trigger than the flushSync inside render-phase effect in #18546).
+//
+// NOTE: This only reproduces without async mode (SVELTE_NO_ASYNC=true).
+export default test({
+	mode: ['client'],
+	compileOptions: {
+		dev: false
+	},
+	async test({ assert, target }) {
+		const [grow1, grow2, change] = target.querySelectorAll('button');
+
+		// Initial render
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>grow1</button><button>grow2</button><button>change</button><div>columns: 1</div>'
+		);
+
+		// First growth step - creates some columns and measures them
+		// During measurement, an action's update writes state mid-flush
+		grow1?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>grow1</button><button>grow2</button><button>change</button><div>columns: 2</div>'
+		);
+
+		// Second growth step - this is where the bug manifests
+		// The action's update during the first step may have created
+		// an unscheduled batch that gets merged, and subsequent updates
+		// may hit the "already dirty, bail" path
+		grow2?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>grow1</button><button>grow2</button><button>change</button><div>columns: 3</div>'
+		);
+
+		// Change step - should update the columns
+		change?.click();
+		await tick();
+		assert.htmlEqual(
+			target.innerHTML,
+			'<button>grow1</button><button>grow2</button><button>change</button><div>columns: 4</div>'
+		);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/batch-created-during-flush-action-update/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/batch-created-during-flush-action-update/main.svelte
@@ -1,0 +1,34 @@
+<script>
+	let count = $state(1);
+	let columns = $state(1);
+	let measured_width = $state(0);
+
+	function measure(node) {
+		// Action's update runs during flush - this writes state mid-batch
+		// which can cause the batch to not be scheduled properly
+		measured_width = node.clientWidth;
+	}
+
+	// Derived that depends on count - this creates the chain of effects
+	let derived_count = $derived.by(() => {
+		return count;
+	});
+
+	// Create some elements with actions that measure
+	function grow() {
+		count++;
+		// When count changes, the derived updates, which may cause
+		// the action's update to run during the flush, writing to columns
+		columns = count + 1;
+	}
+
+	function change() {
+		count++;
+		columns = count + 2;
+	}
+</script>
+
+<button onclick={grow}>grow1</button>
+<button onclick={grow}>grow2</button>
+<button onclick={change}>change</button>
+<div use:measure>columns: {columns}</div>


### PR DESCRIPTION
Fixes #18761

When a state write lands while a batch is being processed, the batch gets created but never scheduled because the guard skips queue_micro_task. When the flush exits through #find_earlier_batch(), that pickup is skipped, and the batch stays unstarted forever.

This fix modifies the schedule() method to not bail when a branch is already dirty, instead continuing to traverse to root and adding it to the current batch's roots (with dedup). This ensures that even if a batch is dropped (its roots are marked dirty but don't belong to any batch), subsequent batches can still traverse these dirty branches.