### PR TITLE
fix: recognise `aria-braillelabel` and `aria-brailleroledescription` as known ARIA attributes

### DIFF
--- a/.changeset/wild-cases-smile.md
+++ b/.changeset/wild-cases-smile.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: recognise `aria-braillelabel` and `aria-brailleroledescription` as known ARIA attributes

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/constants.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/constants.js
@@ -4,7 +4,7 @@ import { roles as roles_map, elementRoles } from 'aria-query';
 import { AXObjects, elementAXObjects } from 'axobject-query';
 
 export const aria_attributes =
-	'activedescendant atomic autocomplete busy checked colcount colindex colspan controls current describedby description details disabled dropeffect errormessage expanded flowto grabbed haspopup hidden invalid keyshortcuts label labelledby level live modal multiline multiselectable orientation owns placeholder posinset pressed readonly relevant required roledescription rowcount rowindex rowspan selected setsize sort valuemax valuemin valuenow valuetext'.split(
+	'activedescendant atomic autocomplete braillelabel brailleroledescription busy checked colcount colindex colspan controls current describedby description details disabled dropeffect errormessage expanded flowto grabbed haspopup hidden invalid keyshortcuts label labelledby level live modal multiline multiselectable orientation owns placeholder posinset pressed readonly relevant required roledescription rowcount rowindex rowspan selected setsize sort valuemax valuemin valuenow valuetext'.split(
 		' '
 	);
 

--- a/packages/svelte/tests/validator/samples/a11y-aria-props/input.svelte
+++ b/packages/svelte/tests/validator/samples/a11y-aria-props/input.svelte
@@ -1,1 +1,2 @@
 <input type="image" aria-labeledby="foo">
+<div aria-braillelabel="foo" aria-brailleroledescription="bar"></div>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (no existing issue found; this is a self contained one line data fix)
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## What breaks

`aria-braillelabel` and `aria-brailleroledescription` are valid ARIA attributes, but the compiler reports them as unknown:

```svelte
<button aria-braillelabel="***">
	<img alt="3 out of 5 stars" src="three_stars.png" />
</button>
```

```
a11y_unknown_aria_attribute: Unknown aria attribute 'aria-braillelabel'
```

The only workaround is `<!-- svelte-ignore a11y_unknown_aria_attribute -->`, which also suppresses genuine typos on the same element.

## Where

The known ARIA attribute names are hand maintained as a space separated string in `packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/constants.js:6`, and the warning is raised in `packages/svelte/src/compiler/phases/2-analyze/visitors/shared/a11y/index.js:120`:

```js
const type = name.slice(5);
if (!aria_attributes.includes(type)) {
	const match = fuzzymatch(type, aria_attributes);
	w.a11y_unknown_aria_attribute(attribute, type, match);
}
```

## The normative rule

Both attributes are defined in [Accessible Rich Internet Applications (WAI-ARIA) 1.3](https://www.w3.org/TR/wai-aria-1.3/), W3C Working Draft 04 June 2026, section 6.8 "Definitions of States and Properties (all aria-* attributes)".

[`aria-braillelabel` (property)](https://www.w3.org/TR/wai-aria-1.3/#aria-braillelabel):

> Defines a string value that labels the current element, which is intended to be converted into Braille. See related `aria-label`.

[`aria-brailleroledescription` (property)](https://www.w3.org/TR/wai-aria-1.3/#aria-brailleroledescription):

> Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille. See related `aria-roledescription`.

Both are also documented on MDN ([aria-braillelabel](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-braillelabel), [aria-brailleroledescription](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-brailleroledescription)) and shipped in browsers.

## Why the current code contradicts it

The list is a strict subset of the ARIA 1.3 state and property set: these two names are the only ones missing, so the compiler calls a spec defined attribute "unknown".

Two further points that make this a plain omission rather than a deliberate exclusion:

1. **The same function already disagrees with itself.** A few lines below the unknown attribute check, `a11y/index.js` validates the attribute *value* against `aria` from `aria-query`, and `aria-query@5.3.1` does define both attributes:

   ```
   $ node -e "const {aria}=require('aria-query'); console.log(aria.get('aria-braillelabel'))"
   { type: 'string' }
   ```

   So Svelte type checks the value of `aria-braillelabel` correctly while simultaneously warning that the attribute does not exist. Diffing the two sources:

   ```
   in aria-query, NOT in svelte: [ 'braillelabel', 'brailleroledescription' ]
   in svelte, NOT in aria-query: []
   ```

2. **The list already targets ARIA 1.3.** `description` is in the list and, like the braille attributes, does not exist in [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/); it was added by #7302 for exactly this reason. This PR is the same fix for the two attributes that were introduced alongside it.

## How I proved it

Extended the existing `a11y-aria-props` validator sample, which is the fixture that covers this warning:

```svelte
<input type="image" aria-labeledby="foo">
<div aria-braillelabel="foo" aria-brailleroledescription="bar"></div>
```

`warnings.json` is unchanged, so the sample now asserts that the two braille attributes produce no warning while the neighbouring typo still does.

Counterfactual, with only the source change reverted and the test left in place:

```
FAIL  packages/svelte/tests/validator/test.ts > a11y-aria-props
AssertionError: expected [ { ...(4) }, { ...(4) }, { ...(4) }, ...(1) ] to deeply equal [ { ...(4) }, { ...(4) } ]

+   {
+     "code": "a11y_unknown_aria_attribute",
+     "message": "Unknown aria attribute 'aria-braillelabel'",
+   },
+   {
+     "code": "a11y_unknown_aria_attribute",
+     "message": "Unknown aria attribute 'aria-brailleroledescription'",
+   },
```

With the fix restored the sample passes again.

Full checks on this branch:

- `pnpm test`: `Test Files 34 passed (34)`, `Tests 7769 passed | 55 skipped (7824)`
- `pnpm check` in `packages/svelte`: clean
- `pnpm lint` (eslint + `prettier --check .`): clean
