### PR TITLE
fix: don't update props of dynamic component that is about to be replaced

### DIFF
--- a/.changeset/quiet-rivers-return.md
+++ b/.changeset/quiet-rivers-return.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't update props of dynamic component that is about to be replaced

--- a/packages/svelte/src/internal/client/constants.js
+++ b/packages/svelte/src/internal/client/constants.js
@@ -50,6 +50,13 @@ export const HEAD_EFFECT = 1 << 18;
 export const EFFECT_PRESERVED = 1 << 19;
 export const USER_EFFECT = 1 << 20;
 export const EFFECT_OFFSCREEN = 1 << 25;
+/**
+ * Set on the block effect that manages a dynamic component (`<svelte:component>`
+ * or a runes-mode `<Component>` whose reference can change). When this block is
+ * dirty, the component it currently renders is about to be replaced, so eager
+ * effects inside the outgoing component must not fire with the new props.
+ */
+export const COMPONENT_BLOCK = 1 << 26;
 
 // Flags exclusive to deriveds
 /**

--- a/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
+++ b/packages/svelte/src/internal/client/dom/blocks/svelte-component.js
@@ -1,5 +1,5 @@
 /** @import { TemplateNode, Dom } from '#client' */
-import { EFFECT_TRANSPARENT } from '#client/constants';
+import { COMPONENT_BLOCK, EFFECT_TRANSPARENT } from '#client/constants';
 import { block } from '../../reactivity/effects.js';
 import {
 	hydrate_next,
@@ -57,5 +57,5 @@ export function component(node, get_component, render_fn) {
 		}
 
 		branches.ensure(component, component && ((target) => render_fn(target, component)));
-	}, EFFECT_TRANSPARENT);
+	}, EFFECT_TRANSPARENT | COMPONENT_BLOCK);
 }

--- a/packages/svelte/src/internal/client/reactivity/sources.js
+++ b/packages/svelte/src/internal/client/reactivity/sources.js
@@ -28,7 +28,8 @@ import {
 	ASYNC,
 	WAS_MARKED,
 	CONNECTED,
-	REACTION_IS_UPDATING
+	REACTION_IS_UPDATING,
+	COMPONENT_BLOCK
 } from '#client/constants';
 import * as e from '../errors.js';
 import { legacy_mode_flag, tracing_mode_flag } from '../../flags/index.js';
@@ -289,11 +290,46 @@ export function flush_eager_effects() {
 		}
 
 		if (dirty) {
-			update_effect(effect);
+			// If a dynamic component that is an ancestor of this eager effect is about
+			// to be swapped out (its block effect is dirty), then the component instance
+			// owning this effect is going to be destroyed before the flush. Running it
+			// now would observe props that belong to the *new* component, so we skip it
+			// (e.g. `$inspect(...)` firing with `undefined` for a component that is being
+			// replaced). See https://github.com/sveltejs/svelte/issues/16135
+			if (!is_inside_dirty_component(effect)) {
+				update_effect(effect);
+			}
 		}
 	}
 
 	eager_effects.clear();
+}
+
+/**
+ * Returns `true` if `effect` is nested inside a dynamic component (`<svelte:component>`
+ * or a runes-mode `<Component>` whose reference can change) that is about to be replaced —
+ * i.e. the component's block effect is `DIRTY`, which (because that block only reads the
+ * component value) guarantees the component instance owning this effect will be destroyed
+ * before the flush. Nested dynamic components are also taken into account: if an inner
+ * dynamic component is clean but it is contained in an outer dynamic component that is
+ * being swapped out, the effect will be destroyed with the outer component and must not run.
+ * @param {Effect} effect
+ */
+function is_inside_dirty_component(effect) {
+	var e = effect.parent;
+
+	while (e !== null) {
+		// A dirty component block guarantees its instance is destroyed before the flush.
+		// If a component block is clean we keep walking — an ancestor dynamic component
+		// (into which this one is nested) might be the one being swapped out.
+		if ((e.f & COMPONENT_BLOCK) !== 0 && (e.f & DIRTY) !== 0) {
+			return true;
+		}
+
+		e = e.parent;
+	}
+
+	return false;
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/_config.js
@@ -1,0 +1,24 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, logs }) {
+		const [btn] = target.querySelectorAll('button');
+
+		btn.click();
+		flushSync();
+
+		assert.deepEqual(logs, [
+			'prop1',
+			'init',
+			'prop1',
+			'prop1',
+			'update',
+			'prop2'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/comp1.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/comp1.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { prop1 } = $props();
+	$inspect('prop1', prop1).with((type, label, value) => console.log(label, type, value));
+</script>
+
+Comp1: {prop1}

--- a/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/inspect-same-component-props-update/main.svelte
@@ -1,0 +1,15 @@
+<script>
+	import Comp1 from './comp1.svelte';
+
+	let Component = $state(Comp1);
+	let props = $state({ prop1: 'prop1' });
+
+	function update() {
+		// same component, only props change
+		props = { prop1: 'prop2' };
+	}
+</script>
+
+<Component {...props} />
+
+<button onclick={update}>Update Props</button>

--- a/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/_config.js
@@ -1,0 +1,34 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	compileOptions: {
+		dev: true
+	},
+
+	async test({ assert, target, logs }) {
+		const [btn] = target.querySelectorAll('button');
+
+		// Swap Comp1 -> Comp2, changing the props at the same time
+		btn.click();
+		flushSync();
+
+		// Swap Comp2 -> Comp1 again
+		btn.click();
+		flushSync();
+
+		// The outgoing component must never observe props belonging to the incoming
+		// component (which would log e.g. `prop1 update undefined`) — see #16135
+		assert.deepEqual(logs, [
+			'prop1',
+			'init',
+			'prop1',
+			'prop2',
+			'init',
+			'prop2',
+			'prop1',
+			'init',
+			'prop1'
+		]);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/comp1.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/comp1.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { prop1 } = $props();
+	$inspect('prop1', prop1).with((type, label, value) => console.log(label, type, value));
+</script>
+
+Comp1: {prop1}

--- a/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/comp2.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/comp2.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { prop2 } = $props();
+	$inspect('prop2', prop2).with((type, label, value) => console.log(label, type, value));
+</script>
+
+Comp2: {prop2}

--- a/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/svelte-component-props-and-component-change/main.svelte
@@ -1,0 +1,23 @@
+<script>
+	import Comp1 from './comp1.svelte';
+	import Comp2 from './comp2.svelte';
+
+	let Component = $state(Comp1);
+	let props = $state({
+		prop1: 'prop1'
+	});
+
+	function toggleComp() {
+		if (Component == Comp1) {
+			Component = Comp2;
+			props = { prop2: 'prop2' };
+		} else {
+			Component = Comp1;
+			props = { prop1: 'prop1' };
+		}
+	}
+</script>
+
+<Component {...props} />
+
+<button onclick={toggleComp}>Swap Components</button>


### PR DESCRIPTION
Fixes #16135

## Problem

When a dynamic component (`<svelte:component>` or a runes-mode `<Component>` whose
reference can change) is swapped out **at the same time** as its props change, the
*outgoing* component briefly observes the *incoming* component's props.

The reason is that `$inspect` (and `$state.eager`) are *eager* effects: they run
synchronously inside `set()`, before the dynamic-component block effect gets a
chance to swap the branch during the flush. So the outgoing component fires a
spurious update with the new props, e.g.:

```
init prop1 prop1
update prop1 undefined   // outgoing component receives the incoming component's props
init prop2 prop2
```

Expected:

```
init prop1 prop1
init prop2 prop2
```

Regular `$effect`/`$derived` were already handled (see #16601), but eager effects
were not.

## Fix

- Tag the block effect that manages a dynamic component with a new `COMPONENT_BLOCK` flag.
- In `flush_eager_effects`, skip an eager effect when it lives under a `COMPONENT_BLOCK`
  that is `DIRTY` — since that block only reads the component value, a dirty block
  guarantees the owning component instance is destroyed before the flush, so the effect
  must not observe the new props. Nested dynamic components are handled too.
- The check is `DIRTY`-only (not `MAYBE_DIRTY`) so there is no risk of suppressing an
  effect when the component instance actually survives.

## Tests

- Added a regression test (`svelte-component-props-and-component-change`) that swaps
  `Comp1` ↔ `Comp2` while changing props and asserts the outgoing component never
  receives an update. Fails without this PR, passes with it.
- Added a guard test (`inspect-same-component-props-update`) confirming that when the
  component stays the same and only props change, `$inspect` still fires.

## Changeset

Added `.changeset/quiet-rivers-return.md` (`svelte` patch).

## Testing

- `pnpm test` — 7773 passed | 55 skipped | 0 failed