### PR TITLE
fix: serialize `<textarea>` default values during server rendering

### DIFF
--- a/.changeset/heavy-pandas-shout.md
+++ b/.changeset/heavy-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: serialize `<textarea>` default values during server rendering

--- a/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
+++ b/packages/svelte/src/compiler/phases/3-transform/server/visitors/shared/element.js
@@ -88,6 +88,13 @@ export function build_element_attributes(node, context, transform) {
 				attributes.push(attribute);
 				// deopt to spread at runtime, where we can handle interaction of value/defaultValue etc
 				has_spread = true;
+			} else if (
+				node.type === 'RegularElement' &&
+				node.name === 'textarea' &&
+				attribute.name === 'defaultValue' &&
+				renders_default_value_as_content(node)
+			) {
+				content = b.call('$.escape', build_attribute_value(attribute.value, context, transform));
 				// the defaultValue/defaultChecked properties don't exist as attributes
 			} else if (attribute.name !== 'defaultValue' && attribute.name !== 'defaultChecked') {
 				if (attribute.name === 'class') {
@@ -291,6 +298,23 @@ export function build_element_attributes(node, context, transform) {
 	}
 
 	return content;
+}
+
+/**
+ * A `<textarea>` has no value attribute, so `defaultValue` can only be serialized as its content,
+ * which is possible when nothing else already provides one.
+ * @param {AST.RegularElement} node
+ */
+function renders_default_value_as_content(node) {
+	return (
+		node.fragment.nodes.length === 0 &&
+		!node.attributes.some(
+			(attribute) =>
+				attribute.type === 'SpreadAttribute' ||
+				((attribute.type === 'Attribute' || attribute.type === 'BindDirective') &&
+					attribute.name === 'value')
+		)
+	);
 }
 
 /**

--- a/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/_config.js
+++ b/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/_config.js
@@ -1,0 +1,3 @@
+import { test } from '../../test';
+
+export default test({});

--- a/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/_expected.html
+++ b/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/_expected.html
@@ -1,0 +1,4 @@
+<textarea>hello</textarea>
+<textarea>world</textarea>
+<textarea>content wins</textarea>
+<textarea>value wins</textarea>

--- a/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/main.svelte
+++ b/packages/svelte/tests/server-side-rendering/samples/textarea-default-value/main.svelte
@@ -1,0 +1,8 @@
+<script>
+	let dynamic = 'world';
+</script>
+
+<textarea defaultValue="hello"></textarea>
+<textarea defaultValue={dynamic}></textarea>
+<textarea defaultValue="hello">content wins</textarea>
+<textarea defaultValue="hello" value="value wins"></textarea>


### PR DESCRIPTION
`defaultValue` is supported on `<textarea>` on the client (it is typed in `HTMLTextareaAttributes` and covered by the `form-default-value` runtime test), but the server renderer drops it.

```svelte
<textarea defaultValue="hello"></textarea>
```

renders as `<textarea></textarea>` on the server, while the client renders `<textarea>hello</textarea>`, because `textarea.defaultValue = 'hello'` sets the element's content. The default value therefore never appears without JS, and there is a flash of an empty textarea before hydration fills it in. This is the same problem #18733 fixed for `<input>`, which left `<textarea>` behind because a textarea's default value is its content rather than an attribute.

The fix serializes `defaultValue` as the element's content, but only when nothing else already supplies it, mirroring how the client picks between assigning `defaultValue` directly and calling `set_default_value` to preserve the current value:

- `<textarea defaultValue="hello">content wins</textarea>` keeps rendering its children
- `<textarea defaultValue="hello" value="value wins"></textarea>` keeps rendering the value
- spreads are left to the existing spread path

Added an SSR test sample covering all four cases. It fails on `main` (the first two textareas render empty) and passes with this change.
