### PR TITLE
fix: don't crash when aborting a deferred out transition before it starts

### DIFF
--- a/.changeset/deferred-outro-reset.md
+++ b/.changeset/deferred-outro-reset.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't crash when aborting a deferred out transition before it starts

--- a/packages/svelte/src/internal/client/dom/elements/transitions.js
+++ b/packages/svelte/src/internal/client/dom/elements/transitions.js
@@ -359,9 +359,9 @@ function animate(element, options, counterpart, t2, on_begin, on_finish) {
 				aborted = true;
 				a?.abort();
 			},
-			deactivate: () => a.deactivate(),
-			reset: () => a.reset(),
-			t: () => a.t()
+			deactivate: () => a?.deactivate(),
+			reset: () => a?.reset(),
+			t: () => a?.t()
 		};
 	}
 

--- a/packages/svelte/tests/runtime-runes/samples/transition-deferred-out-effect-resume/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/transition-deferred-out-effect-resume/_config.js
@@ -1,0 +1,13 @@
+import { flushSync } from '../../../../src/index-client.js';
+import { test } from '../../test';
+
+export default test({
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+
+		button.click();
+		flushSync();
+
+		assert.htmlEqual(target.innerHTML, '<button>hide</button> <p>hello</p>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/transition-deferred-out-effect-resume/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/transition-deferred-out-effect-resume/main.svelte
@@ -1,0 +1,21 @@
+<script>
+	let show = $state(true);
+
+	$effect(() => {
+		if (!show) show = true;
+	});
+
+	/** @param {Element} node */
+	function deferred(node) {
+		return () => ({
+			duration: 100,
+			css: (t) => `opacity: ${t}`
+		});
+	}
+</script>
+
+<button onclick={() => (show = false)}>hide</button>
+
+{#if show}
+	<p out:deferred>hello</p>
+{/if}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
- [x] If this PR changes code within `packages/svelte/src`, add a changeset (`npx changeset`).

### Tests and linting

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Fixes #18773

This is the crash from that issue: an `{#if}` goes away, an out-only deferred transition starts (`out:fn` where `fn` returns another function, same idea as `crossfade`), and then an `$effect` turns the block back on in the same update.

The outro isn't a real animation yet — Svelte waits a microtask before creating it. When the branch comes back, `resume` calls `reset()` on that placeholder. `abort` already treated "not started" as fine; `reset` / `deactivate` / `t` did not, so you got:

```
TypeError: Cannot read properties of undefined (reading 'reset')
```

I made those three match `abort`. If the outro never started, cancelling it is a no-op, and the block stays on the page instead of throwing.

There's a runtime-runes sample that clicks hide while an `$effect` immediately sets the flag back to `true`. That used to throw; it doesn't now.

Local: `pnpm test runtime-runes -t transition-deferred-out-effect-resume`
