### PR TITLE
fix: avoid duplicate reaction when reconnecting a derived

### DIFF
--- a/.changeset/lazy-rivers-connect.md
+++ b/.changeset/lazy-rivers-connect.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: avoid duplicate reaction when reconnecting a derived after its reader is hidden

--- a/packages/svelte/src/internal/client/runtime.js
+++ b/packages/svelte/src/internal/client/runtime.js
@@ -736,7 +736,10 @@ function reconnect(derived) {
 	if (derived.deps === null) return;
 
 	for (const dep of derived.deps) {
-		(dep.reactions ??= []).push(derived);
+		var reactions = (dep.reactions ??= []);
+		if (index_of.call(reactions, derived) === -1) {
+			reactions.push(derived);
+		}
 
 		if ((dep.f & DERIVED) !== 0 && (dep.f & CONNECTED) === 0) {
 			unfreeze_derived_effects(/** @type {Derived} */ (dep));


### PR DESCRIPTION
Fixes #18781

## What's the problem

A component-owned `$derived` stays reachable after `unmount()` when this happens:

1. The component's derived is rendered inside an `{#if}` in its parent, so while visible the derived is "connected" to its dependencies.
2. The `{#if}` is hidden, the effect reading the derived is torn down, and once it has no more readers the derived gets disconnected.
3. While hidden, a nested reactive object the derived depends on is replaced (e.g. `shared.data = { value: 1 }`).
4. The `{#if}` is shown again, and `get()` reconnects the derived.

After step 4 the derived can no longer be collected, leaking the unmounted component.

## Why it leaks

In `runtime.js`, `reconnect()` pushes the derived into each dependency's `reactions` array without checking whether it's already there:

```js
for (const dep of derived.deps) {
	(dep.reactions ??= []).push(derived); // no dedup
	...
}
```

`remove_reaction()` removes only a single occurrence, so the leftover entry stays behind as a strong reference:

`source.reactions → derived → component closure → marker`

and the unmounted component is never garbage collected.

## Verified on the repository source

All evidence below was collected on this repository's `main` at `273e32a` (`svelte@5.57.0`), not on a published package.

### 1. `reconnect()` runs with the derived already registered

Breakpoint at `packages/svelte/src/internal/client/runtime.js:731` (the unguarded `push`), conditional on `dep.reactions.length > 1`:

![breakpoint, call stack, variables and watch](https://raw.githubusercontent.com/xia-chao/svelte/72bb23b7630fe182f7a8af0d4ed1ed2fda9b753d/.github/evidence/18781/01-breakpoint-overview.webp)

The same frame shows:

| expression | value |
| --- | --- |
| `dep.reactions.length` | `2` |
| `dep.reactions.filter(r => r === derived).length` | `1` |
| `dep.reactions[1] === derived` | `true` |
| `derived.f` / `dep.reactions[1].f` | `34306` / `34306` |
| `derived.reactions` | `null` — no readers left |

So the derived is registered twice on the same dependency, while it has no readers of its own.

### 2. The trigger is the reconnect path

![call stack](https://raw.githubusercontent.com/xia-chao/svelte/72bb23b7630fe182f7a8af0d4ed1ed2fda9b753d/.github/evidence/18781/02-call-stack.webp)

`reconnect` is reached from `get()` (`runtime.js:705`), which was entered from the component's template effect (`Retained.js:21` → `template_effect` → `consequent` → `BranchManager`) — i.e. from showing the `{#if}` again.

### 3. Consequence, and the exact trigger

![four-mode comparison and accumulation](https://raw.githubusercontent.com/xia-chao/svelte/72bb23b7630fe182f7a8af0d4ed1ed2fda9b753d/.github/evidence/18781/03-modes-and-accumulation.webp)

30 component instances are mounted and unmounted; after `unmount()` the runner crosses task boundaries and forces GC ten times. Only the `replace` sequence leaks, which rules out "hiding" and "changing data" as the trigger — it is replacing that nested reactive object *while the reader is hidden*. Note `elements left in the DOM: 0` while all 30 markers are still retained, so this is a JS-side retention, not stale DOM.

### 4. The fix stops it

![patch effectiveness](https://raw.githubusercontent.com/xia-chao/svelte/72bb23b7630fe182f7a8af0d4ed1ed2fda9b753d/.github/evidence/18781/04-patch-effectiveness.webp)

The identical reproduction is run three times, alternating between the unpatched and patched `reconnect()` — the only variable is the patch.

## The fix

Only push the derived if it isn't already in the dependency's `reactions` array:

```js
for (const dep of derived.deps) {
	var reactions = (dep.reactions ??= []);
	if (index_of.call(reactions, derived) === -1) {
		reactions.push(derived);
	}
	...
}
```

## Test plan

Two tests in `packages/svelte/tests/signals/test.ts`, both of which fail without the fix:

- `reconnecting a derived does not add a duplicate reaction` — asserts the graph invariant directly. Without the fix: `derived registered 3 times ... expected 1`.
- `reconnect() is idempotent` — the reverse check. It connects the derived, detaches it, then calls `reconnect()` three times and asserts the dependency registers it exactly once. This is the invariant that makes `remove_reaction()`'s single-removal semantics sufficient; without the fix the count becomes 3.

`reconnect()` is exported for these tests — it is not part of the public API, and no runtime behaviour changes.

- Existing suites: `tests/signals` 107 passed, `tests/runtime-runes` 2703 passed, `tests/runtime-legacy` 3304 passed.
- CI is green on all jobs (Tests on Linux/macOS/Windows, `TestNoAsync`, Lint, TSGo, Benchmarks).

A memory leak isn't observable through the jsdom-based unit harness (GC/WeakRef only), so the leak itself is verified with the WeakRef + `--expose-gc` repro; the regression test asserts the graph invariant directly.

A note on `async_mode_flag`: the reproduction does not need `experimental.async`. The component output used above does not import `svelte/internal/flags/async`, so the flag is `false` in this run.

