### PR TITLE
chore: scope.js stops importing from the analysis visitors

### DIFF
--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/ClassDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/ClassDeclaration.js
@@ -1,7 +1,7 @@
 /** @import { ClassDeclaration } from 'estree' */
 /** @import { Context } from '../types' */
 import * as w from '../../../warnings.js';
-import { validate_identifier_name } from './shared/utils.js';
+import { validate_identifier_name } from '../../scope.js';
 
 /**
  * @param {ClassDeclaration} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/FunctionDeclaration.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/FunctionDeclaration.js
@@ -1,7 +1,7 @@
 /** @import { FunctionDeclaration } from 'estree' */
 /** @import { Context } from '../types' */
 import { visit_function } from './shared/function.js';
-import { validate_identifier_name } from './shared/utils.js';
+import { validate_identifier_name } from '../../scope.js';
 
 /**
  * @param {FunctionDeclaration} node

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/VariableDeclarator.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/VariableDeclarator.js
@@ -1,8 +1,8 @@
 /** @import { Expression, Identifier, Literal, VariableDeclarator } from 'estree' */
 /** @import { Binding } from '#compiler' */
 /** @import { Context } from '../types' */
-import { get_rune } from '../../scope.js';
-import { ensure_no_module_import_conflict, validate_identifier_name } from './shared/utils.js';
+import { get_rune, validate_identifier_name } from '../../scope.js';
+import { ensure_no_module_import_conflict } from './shared/utils.js';
 import * as e from '../../../errors.js';
 import * as w from '../../../warnings.js';
 import { extract_paths } from '../../../utils/ast.js';

--- a/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
+++ b/packages/svelte/src/compiler/phases/2-analyze/visitors/shared/utils.js
@@ -247,44 +247,6 @@ export function is_pure(node, context) {
 }
 
 /**
- * Checks if the name is valid, which it is when it's not starting with (or is) a dollar sign or if it's a function parameter.
- * The second argument is the depth of the scope, which is there for backwards compatibility reasons: In Svelte 4, you
- * were allowed to define `$`-prefixed variables anywhere below the top level of components. Once legacy mode is gone, this
- * argument can be removed / the call sites adjusted accordingly.
- * @param {Binding | null} binding
- * @param {number | undefined} [function_depth]
- */
-export function validate_identifier_name(binding, function_depth) {
-	if (!binding) return;
-
-	const declaration_kind = binding.declaration_kind;
-
-	if (
-		declaration_kind !== 'synthetic' &&
-		declaration_kind !== 'param' &&
-		declaration_kind !== 'rest_param' &&
-		(!function_depth || function_depth <= 1)
-	) {
-		const node = binding.node;
-
-		if (node.name === '$') {
-			e.dollar_binding_invalid(node);
-		} else if (
-			node.name.startsWith('$') &&
-			// import type { $Type } from "" - these are normally already filtered out,
-			// but for the migration they aren't, and throwing here is preventing the migration to complete
-			// TODO -> once migration script is gone we can remove this check
-			!(
-				binding.initial?.type === 'ImportDeclaration' &&
-				/** @type {any} */ (binding.initial).importKind === 'type'
-			)
-		) {
-			e.dollar_prefix_invalid(node);
-		}
-	}
-}
-
-/**
  * Checks that the exported name is not a derived or reassigned state variable.
  * @param {Node} node
  * @param {Scope} scope

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -14,7 +14,6 @@ import {
 } from '../utils/ast.js';
 import { is_reserved, is_rune } from '../../utils.js';
 import { determine_slot } from '../utils/slot.js';
-import { validate_identifier_name } from './2-analyze/visitors/shared/utils.js';
 
 const UNKNOWN = Symbol('unknown');
 /** Includes `BigInt` */
@@ -1506,4 +1505,42 @@ export function should_proxy(node, scope) {
 	}
 
 	return true;
+}
+
+/**
+ * Checks if the name is valid, which it is when it's not starting with (or is) a dollar sign or if it's a function parameter.
+ * The second argument is the depth of the scope, which is there for backwards compatibility reasons: In Svelte 4, you
+ * were allowed to define `$`-prefixed variables anywhere below the top level of components. Once legacy mode is gone, this
+ * argument can be removed / the call sites adjusted accordingly.
+ * @param {Binding | null} binding
+ * @param {number | undefined} [function_depth]
+ */
+export function validate_identifier_name(binding, function_depth) {
+	if (!binding) return;
+
+	const declaration_kind = binding.declaration_kind;
+
+	if (
+		declaration_kind !== 'synthetic' &&
+		declaration_kind !== 'param' &&
+		declaration_kind !== 'rest_param' &&
+		(!function_depth || function_depth <= 1)
+	) {
+		const node = binding.node;
+
+		if (node.name === '$') {
+			e.dollar_binding_invalid(node);
+		} else if (
+			node.name.startsWith('$') &&
+			// import type { $Type } from "" - these are normally already filtered out,
+			// but for the migration they aren't, and throwing here is preventing the migration to complete
+			// TODO -> once migration script is gone we can remove this check
+			!(
+				binding.initial?.type === 'ImportDeclaration' &&
+				/** @type {any} */ (binding.initial).importKind === 'type'
+			)
+		) {
+			e.dollar_prefix_invalid(node);
+		}
+	}
 }


### PR DESCRIPTION
`phases/scope.js` imported `validate_identifier_name` from `2-analyze/visitors/shared/utils.js`, which imports `get_rune` back from `scope.js`. The check reads a `Binding` and `Scope.declare` is its main caller, so it now lives in `scope.js`. No behaviour change.