### PR TITLE
docs: clarify options_missing_custom_element warning re: ShadowRoot CSS extraction

### DIFF
--- a/.changeset/clarify-options-missing-custom-element.md
+++ b/.changeset/clarify-options-missing-custom-element.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+docs: clarify `options_missing_custom_element` warning regarding ShadowRoot CSS extraction

--- a/documentation/docs/98-reference/.generated/compile-warnings.md
+++ b/documentation/docs/98-reference/.generated/compile-warnings.md
@@ -776,7 +776,7 @@ The `immutable` option has been deprecated. It will have no effect in runes mode
 ### options_missing_custom_element
 
 ```
-The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?
+The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`
 ```
 
 ### options_removed_enable_sourcemap

--- a/packages/svelte/messages/compile-warnings/options.md
+++ b/packages/svelte/messages/compile-warnings/options.md
@@ -8,7 +8,7 @@
 
 ## options_missing_custom_element
 
-> The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?
+> The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`
 
 ## options_removed_enable_sourcemap
 

--- a/packages/svelte/src/compiler/warnings.js
+++ b/packages/svelte/src/compiler/warnings.js
@@ -556,11 +556,11 @@ export function options_deprecated_immutable(node) {
 }
 
 /**
- * The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?
+ * The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`
  * @param {null | NodeLike} node
  */
 export function options_missing_custom_element(node) {
-	w(node, 'options_missing_custom_element', `The \`customElement\` option is used when generating a custom element. Did you forget the \`customElement: true\` compile option?\nhttps://svelte.dev/e/options_missing_custom_element`);
+	w(node, 'options_missing_custom_element', `The \`customElement\` option is used when generating a custom element, but \`customElement: true\` (or \`css: 'injected'\`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set \`compilerOptions.customElement: true\` (or \`css: 'injected'\`) in \`svelte.config.js\`\nhttps://svelte.dev/e/options_missing_custom_element`);
 }
 
 /**

--- a/packages/svelte/tests/validator/samples/custom-element-props-identifier-props-option/warnings.json
+++ b/packages/svelte/tests/validator/samples/custom-element-props-identifier-props-option/warnings.json
@@ -5,7 +5,7 @@
 			"column": 2,
 			"line": 3
 		},
-		"message": "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?",
+		"message": "The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`",
 		"start": {
 			"column": 16,
 			"line": 1

--- a/packages/svelte/tests/validator/samples/custom-element-props-identifier-rest/warnings.json
+++ b/packages/svelte/tests/validator/samples/custom-element-props-identifier-rest/warnings.json
@@ -5,7 +5,7 @@
 			"column": 34,
 			"line": 1
 		},
-		"message": "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?",
+		"message": "The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`",
 		"start": {
 			"column": 16,
 			"line": 1

--- a/packages/svelte/tests/validator/samples/custom-element-props-identifier/warnings.json
+++ b/packages/svelte/tests/validator/samples/custom-element-props-identifier/warnings.json
@@ -5,7 +5,7 @@
 			"column": 34,
 			"line": 1
 		},
-		"message": "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?",
+		"message": "The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`",
 		"start": {
 			"column": 16,
 			"line": 1

--- a/packages/svelte/tests/validator/samples/tag-custom-element-options-missing/warnings.json
+++ b/packages/svelte/tests/validator/samples/tag-custom-element-options-missing/warnings.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "options_missing_custom_element",
-		"message": "The `customElement` option is used when generating a custom element. Did you forget the `customElement: true` compile option?",
+		"message": "The `customElement` option is used when generating a custom element, but `customElement: true` (or `css: 'injected'`) is not set in compiler options. If child components are rendered inside a ShadowRoot, their styles will be extracted externally and will not be visible inside the shadow tree. Set `compilerOptions.customElement: true` (or `css: 'injected'`) in `svelte.config.js`",
 		"start": {
 			"line": 1,
 			"column": 16


### PR DESCRIPTION
Relates to #18199.

### What this does

Strengthens the `options_missing_custom_element` compile warning so it explains the actual consequence of missing `customElement: true` / `css: 'injected'`, not just that the option was "forgotten":

- Before: "The `customElement` option is used when generating a custom
  element. Did you forget the `customElement: true` compile option?"
- After: explains that components without this option have their CSS
  extracted externally, which will not reach a ShadowRoot if the
  component is rendered inside a custom element — and names the fix
  (`compilerOptions.customElement: true` or `css: 'injected'` in
  `svelte.config.js`).

### What this does NOT do

This does not change the `inject_styles` logic itself (`css === 'injected' || is_custom_element` in `phases/2-analyze/index.js`), and does not add any warning to child components (e.g. `App.svelte`, `Point.svelte`) that lack the option — today the warning only fires on the component that declares `<svelte:options customElement>`. So this PR makes the existing diagnostic clearer, not louder or more broadly triggered. I think that's a reasonable first step and kept the change minimal/single-purpose, but flagging it explicitly in case a wider fix (e.g. surfacing a hint from child components too) is preferred instead — happy to scope that as a follow-up if so.

### Why (root cause of #18199)

In production builds, child components rendered inside a custom element's ShadowRoot lose their styles if compiled without
`customElement: true` / `css: 'injected'`, because `inject_styles: css === 'injected' || is_custom_element` means their CSS is extracted externally (destined for `<head>`) instead of being emitted via `$.append_styles` into the ShadowRoot. The compiler analyzes each file in isolation, so a plain child component has no way to know at compile time that it will be mounted inside a custom element.

I initially suspected a regression in #17258 (each-block outro/resume reconciliation) and said so on the issue — that's ruled out: the bug reproduces identically at `190e64acd` and `190e64acd~1`, so it predates that PR and is unrelated to it.

### Test plan

- `pnpm vitest run validator` — 336 passed, 4 skipped
- `pnpm test` (full suite) — 7770 passed, 55 skipped
- `pnpm check`, `pnpm eslint`, `pnpm prettier --check` — all clean
- Manually rebuilt the StackBlitz repro from #18199 (linked against this
  branch) and confirmed the improved warning text appears in the build
  output when `customElement`/`css: 'injected'` is missing; confirmed
  setting either option resolves the ShadowRoot styling issue as
  described.
- Added a changeset (`patch`) for the message wording change.

Note: per the PR checklist, I don't have a test that fails without this PR and passes with it, since this is a message-text change rather than a behavior change — the four updated `warnings.json` snapshots assert the new wording going forward. Open to adding a more targeted test if that's not sufficient.