### PR TITLE
fix: resolve the fallback of an each block in the enclosing scope

### DIFF
--- a/.changeset/each-fallback-scope.md
+++ b/.changeset/each-fallback-scope.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: resolve the fallback of an each block in the enclosing scope

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1278,7 +1278,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			for (const child of node.body.nodes) {
 				visit(child, { scope });
 			}
-			if (node.fallback) visit(node.fallback, { scope });
+			if (node.fallback) visit(node.fallback);
 
 			node.metadata = {
 				expression: new ExpressionMetadata(),

--- a/packages/svelte/src/compiler/phases/scope.js
+++ b/packages/svelte/src/compiler/phases/scope.js
@@ -1233,6 +1233,7 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 
 		EachBlock(node, { state, visit }) {
 			visit(node.expression);
+			if (node.fallback) visit(node.fallback);
 
 			// context and children are a new scope
 			const scope = state.scope.child();
@@ -1278,7 +1279,6 @@ export function create_scopes(ast, root, allow_reactive_declarations, parent) {
 			for (const child of node.body.nodes) {
 				visit(child, { scope });
 			}
-			if (node.fallback) visit(node.fallback);
 
 			node.metadata = {
 				expression: new ExpressionMetadata(),

--- a/packages/svelte/tests/runtime-runes/samples/each-fallback-outer-scope/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/each-fallback-outer-scope/_config.js
@@ -1,0 +1,14 @@
+import { flushSync } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	html: '<button>outer</button>',
+
+	test({ assert, target }) {
+		const button = target.querySelector('button');
+		flushSync(() => {
+			button?.click();
+		});
+		assert.htmlEqual(target.innerHTML, '<button>changed</button>');
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/each-fallback-outer-scope/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/each-fallback-outer-scope/main.svelte
@@ -1,0 +1,10 @@
+<script>
+	let items = $state([]);
+	let item = $state('outer');
+</script>
+
+{#each items as item}
+	<p>{item}</p>
+{:else}
+	<button onclick={() => (item = 'changed')}>{item}</button>
+{/each}


### PR DESCRIPTION
In `phases/scope.js`, `EachBlock` visits `node.fallback` with the block's own scope, so `{:else}` resolves the loop's name to the each context. With `let item = $state('outer')` outside and `{#each items as item}…{:else}<button onclick={() => (item = 'changed')}>` the compiler reports "Cannot reassign or bind to each block argument" for a variable that is not the block's argument.

The fallback renders when there is nothing to iterate, so it is visited in the enclosing scope, as an await block's `pending` is.
