### PR TITLE
fix: keep `$state.eager` when used as a variable initializer

### DIFF
--- a/.changeset/state-eager-let-declaration.md
+++ b/.changeset/state-eager-let-declaration.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep `$state.eager` when used as a variable initializer

--- a/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
+++ b/packages/svelte/src/compiler/phases/3-transform/client/visitors/VariableDeclaration.js
@@ -35,6 +35,7 @@ export function VariableDeclaration(node, context) {
 				rune === '$inspect' ||
 				rune === '$inspect.trace' ||
 				rune === '$state.snapshot' ||
+				rune === '$state.eager' ||
 				rune === '$host'
 			) {
 				declarations.push(/** @type {VariableDeclarator} */ (context.visit(declarator)));

--- a/packages/svelte/tests/runtime-runes/samples/state-eager-declaration/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/state-eager-declaration/_config.js
@@ -1,0 +1,5 @@
+import { test } from '../../test';
+
+export default test({
+	html: `<p>20</p>`
+});

--- a/packages/svelte/tests/runtime-runes/samples/state-eager-declaration/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/state-eager-declaration/main.svelte
@@ -1,0 +1,7 @@
+<script>
+	let n = $state(2);
+	let d = $derived(n * 10);
+	let x = $state.eager(d);
+</script>
+
+<p>{x}</p>


### PR DESCRIPTION
fixes #18808

If you write `let x = $state.eager(...)`, the client compiler used to delete that line and then still read `x`. The page crashed with `x is not defined`. Server rendering kept the binding.

Using `$state.eager(...)` directly in the markup already worked. This puts the `let` / `const` form on the same path as `$state.snapshot`.

Added a runtime-runes sample that fails without this change.
