### PR TITLE
fix: preserve component updates after derived effect cleanup

### DIFF
--- a/.changeset/quiet-effects-update.md
+++ b/.changeset/quiet-effects-update.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: preserve component updates when a derived cleans up an effect that was already unlinked

--- a/packages/svelte/src/internal/client/reactivity/effects.js
+++ b/packages/svelte/src/internal/client/reactivity/effects.js
@@ -601,6 +601,9 @@ export function unlink_effect(effect) {
 		if (parent.first === effect) parent.first = next;
 		if (parent.last === effect) parent.last = prev;
 	}
+
+	// A derived can still reference this effect and destroy it after it has been unlinked.
+	effect.prev = effect.next = null;
 }
 
 /**

--- a/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/Item.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/Item.svelte
@@ -1,0 +1,16 @@
+<script>
+	let { item, attachHandle, onIncrement } = $props();
+</script>
+
+<div>
+	<span>{item.id}: {item.value}</span>
+
+	{#if item.id === 'a'}
+		<span>Type A</span>
+	{:else}
+		<span>Type B</span>
+	{/if}
+
+	<button {@attach attachHandle}>drag</button>
+	<button onclick={onIncrement}>+1</button>
+</div>

--- a/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/_config.js
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/_config.js
@@ -1,0 +1,48 @@
+import { tick } from 'svelte';
+import { test } from '../../test';
+
+export default test({
+	async test({ assert, target, logs }) {
+		const buttons = target.querySelectorAll('button');
+		const values = target.querySelectorAll('div > span:first-child');
+		const second = values[1];
+
+		assert.deepEqual(logs.splice(0), ['setup a', 'setup b']);
+
+		for (let value = 1; value <= 3; value += 1) {
+			buttons[1].click();
+			await tick();
+			assert.equal(values[0].textContent, `a: ${value}`);
+			assert.equal(second.textContent, 'b: 0');
+		}
+
+		assert.deepEqual(logs.splice(0), [
+			'cleanup a',
+			'setup a',
+			'cleanup a',
+			'setup a',
+			'cleanup a',
+			'setup a'
+		]);
+
+		buttons[3].click();
+		await tick();
+		assert.equal(second.textContent, 'b: 1');
+		assert.deepEqual(logs.splice(0), ['cleanup b', 'setup b']);
+
+		buttons[4].click();
+		await tick();
+		assert.equal(target.querySelector('div > span:first-child'), second);
+		assert.deepEqual(logs.splice(0), ['cleanup a']);
+
+		buttons[3].click();
+		await tick();
+		assert.equal(second.textContent, 'b: 2');
+		assert.deepEqual(logs.splice(0), ['cleanup b', 'setup b']);
+
+		buttons[4].click();
+		await tick();
+		assert.equal(target.querySelector('div'), null);
+		assert.deepEqual(logs.splice(0), ['cleanup b']);
+	}
+});

--- a/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/attachment.svelte.js
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/attachment.svelte.js
@@ -1,0 +1,15 @@
+export function create_attachment(input) {
+	$effect(() => () => console.log(`cleanup ${input.id}`));
+
+	// This effect has no reactive dependencies or cleanup.
+	$effect(() => console.log(`setup ${input.id}`));
+
+	$effect.pre(() => {
+		void input.index;
+	});
+	$effect(() => {
+		void input.index;
+	});
+
+	return { attach: () => () => {} };
+}

--- a/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/main.svelte
+++ b/packages/svelte/tests/runtime-runes/samples/attachment-derived-effect-cleanup/main.svelte
@@ -1,0 +1,31 @@
+<script>
+	import Item from './Item.svelte';
+	import { create_attachment } from './attachment.svelte.js';
+
+	let items = $state([
+		{ id: 'a', value: 0 },
+		{ id: 'b', value: 0 }
+	]);
+
+	function increment(id) {
+		items = items.map((item) => (item.id === id ? { id: item.id, value: item.value + 1 } : item));
+	}
+</script>
+
+<pre>{JSON.stringify(items)}</pre>
+
+{#each items as item, index (item.id)}
+	{@const attachment = create_attachment({
+		id: item.id,
+		get index() {
+			return index;
+		}
+	})}
+	<Item
+		item={items[index]}
+		attachHandle={attachment.attach}
+		onIncrement={() => increment(item.id)}
+	/>
+{/each}
+
+<button onclick={() => (items = items.slice(1))}>Remove first</button>


### PR DESCRIPTION
Fixes #18149.

Components using attachments in a keyed list can stop receiving updates in production after replacing the list's array. A deferred effect with no dependencies or cleanup is pruned after its first run, but its owning derived can still retain it. When that derived later destroys the effect, stale `prev`/`next` pointers cause a second unlink to disconnect live sibling effects.

Clear the detached effect's sibling pointers in `unlink_effect`, preserving its parent for error propagation. The regression reduces the original drag-and-drop reproduction to Svelte alone and checks repeated updates, sibling isolation, cleanup counts, and keyed-node reuse after removal.

Validation on `6eb720a1b7cafca3ebe0ab5c76674272cd3044f9`:

- The regression fails on untouched source in DOM and hydration modes, with experimental async enabled and disabled, and passes with the fix.
- Full `pnpm test --maxWorkers=4`: 7,784 passed, 55 skipped across 34 files.
- Package build, `pnpm lint`, and `pnpm -r check`: passed.
- Rebuilt the original application and verified trusted Chromium clicks: parent and child both advance through 1, 2, and 3, with no browser errors.

Open and closed PR searches plus nearby lifecycle diffs did not identify an overlapping fix. This draft was developed and reviewed with Codex assistance.

### Before submitting the PR, please make sure you do the following

- [x] References the reported issue; this is a focused bug fix.
- [x] Uses a `fix:` title.
- [x] Explains the problem and solution.
- [x] Includes a regression that fails without the fix.
- [x] Includes a patch changeset for the source change.

### Tests and linting

- [x] Ran the full test suite and project lint.
