### PR TITLE
fix: don't hang `migrate` on a declaration that shares a line with its script tag

### DIFF
--- a/.changeset/migrate-tag-line.md
+++ b/.changeset/migrate-tag-line.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: don't hang `migrate` on a declaration that shares a line with its script tag

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -910,8 +910,10 @@ const instance_script = {
 				start = /** @type {number} */ (parent.start);
 				end = /** @type {number} */ (parent.end);
 			}
-			while (state.str.original[start] !== '\n') start--;
-			while (state.str.original[end] !== '\n') end++;
+			// remove the declaration's whole line, or what there is of it inside the script
+			const script = /** @type {{ start: number; end: number }} */ (state.analysis.instance.ast);
+			while (start > script.start && state.str.original[start] !== '\n') start--;
+			while (end < script.end && state.str.original[end] !== '\n') end++;
 			state.str.update(start, end, '');
 		}
 	},

--- a/packages/svelte/tests/migrate/samples/props-on-script-tag-line/input.svelte
+++ b/packages/svelte/tests/migrate/samples/props-on-script-tag-line/input.svelte
@@ -1,0 +1,2 @@
+<script>export let answer</script>
+<p>{answer}</p>

--- a/packages/svelte/tests/migrate/samples/props-on-script-tag-line/output.svelte
+++ b/packages/svelte/tests/migrate/samples/props-on-script-tag-line/output.svelte
@@ -1,0 +1,3 @@
+<script>
+	let { answer } = $props();</script>
+<p>{answer}</p>


### PR DESCRIPTION
`migrate()` never returned when a declaration shared a line with its `<script>` tag:

```svelte
<script>export let answer</script>
```

The scan that removes a migrated `export let` line looked for a newline in both directions with no bound. It now stops at the script's edges.