### PR TITLE
fix: keep a reactive assignment with no dependencies when `migrate` cannot turn it into a declaration

### DIFF
--- a/.changeset/migrate-keep-assignment.md
+++ b/.changeset/migrate-keep-assignment.md
@@ -1,0 +1,5 @@
+---
+'svelte': patch
+---
+
+fix: keep a reactive assignment with no dependencies when `migrate` cannot turn it into a declaration

--- a/packages/svelte/src/compiler/migrate/index.js
+++ b/packages/svelte/src/compiler/migrate/index.js
@@ -987,8 +987,11 @@ const instance_script = {
 					return;
 				}
 
+				let declared = 0;
 				for (const binding of bindings) {
-					if (binding.reassigned && (ids.includes(binding.node) || expression_ids.length === 0)) {
+					// a binding this statement declares needs its `let` whether or not it is reassigned
+					if (ids.includes(binding.node) || (binding.reassigned && expression_ids.length === 0)) {
+						declared++;
 						check_rune_binding('state');
 						const init =
 							binding.kind === 'state'
@@ -1004,7 +1007,13 @@ const instance_script = {
 					}
 				}
 
-				if (expression_ids.length === 0 && bindings.every((b) => b.kind !== 'store_sub')) {
+				// the statement goes only once every target has a declaration standing in for it
+				if (
+					expression_ids.length === 0 &&
+					bindings.length > 0 &&
+					declared === bindings.length &&
+					bindings.every((b) => b.kind !== 'store_sub')
+				) {
 					state.str.remove(/** @type {number} */ (node.start), /** @type {number} */ (node.end));
 					return;
 				}

--- a/packages/svelte/tests/migrate/samples/labeled-assignment-without-dependencies/input.svelte
+++ b/packages/svelte/tests/migrate/samples/labeled-assignment-without-dependencies/input.svelte
@@ -1,0 +1,8 @@
+<script>
+	$: count = 7;
+	$: other = 8;
+	let obj = {};
+	$: obj.x = 1;
+</script>
+
+<p>{count} {other} {obj.x}</p>

--- a/packages/svelte/tests/migrate/samples/labeled-assignment-without-dependencies/output.svelte
+++ b/packages/svelte/tests/migrate/samples/labeled-assignment-without-dependencies/output.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { run } from 'svelte/legacy';
+
+	let count = $state(7);
+	
+	let other = $state(8);
+	
+	let obj = $state({});
+	run(() => {
+		obj.x = 1;
+	});
+</script>
+
+<p>{count} {other} {obj.x}</p>


### PR DESCRIPTION
`migrate()` dropped a reactive assignment that has no dependencies and put nothing in its place:

```svelte
$: count = 7;          →  (gone, `{count}` now undeclared)
$: obj.x = 1;          →  (gone)
```

A binding the statement declares now always gets its `let`, and the statement is only removed once every target has one; otherwise it becomes `run()`:

```svelte
let count = $state(7);
run(() => { obj.x = 1; });
```